### PR TITLE
(re) Allow simultaneous use of beta endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microsoft/microsoft-graph-types",
+  "name": "@microsoft/microsoft-graph-types-beta",
   "description": "Types for Microsoft Graph objects",
   "version": "1.4.0",
   "types": "microsoft-graph.d.ts",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/microsoftgraph/msgraph-typescript-typings.git"
+    "url": "https://github.com/microsoftgraph/msgraph-typescript-typings.git#beta"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",


### PR DESCRIPTION
It seems that the beta branch has been recreated, the package name in the beta branch is now the same as the in the master branch. This wil cause ts compiler errors when using the both versions simultaneous.

**This wil now fail**
```json
"devDependencies": {
    "@microsoft/microsoft-graph-types": "^1.4.0",
    "@microsoft/microsoft-graph-types-beta": "microsoftgraph/msgraph-typescript-typings#beta",
    "typescript": "^2.9.2"
  }
```

As the reference to the beta does not create a @microsoft/microsoft-graph-types-beta folders in node_modules.

I've updated the package.json name and repo url to allow the use of both endpoints simultaneous again.

**Success with updated package.json**

```json
"devDependencies": {
    "@microsoft/microsoft-graph-types": "^1.4.0",
    "@microsoft/microsoft-graph-types-beta": "git://github.com/RobinBreman/msgraph-typescript-typings.git#beta",
    "typescript": "^2.9.2"
  }
```