### PR TITLE
Revert strict typings and update models with respect to the new metadata

### DIFF
--- a/microsoft-graph.d.ts
+++ b/microsoft-graph.d.ts
@@ -17,6 +17,8 @@ export type FreeBusyStatus = "free" | "tentative" | "busy" | "oof" | "workingEls
 export type LocationType = "default" | "conferenceRoom" | "homeAddress" | "businessAddress" | "geoCoordinates" | "streetAddress" | "hotel" | "restaurant" | "localBusiness" | "postalAddress"
 export type LocationUniqueIdType = "unknown" | "locationStore" | "directory" | "private" | "bing"
 export type ActivityDomain = "unknown" | "work" | "personal" | "unrestricted"
+export type MailTipsType = "automaticReplies" | "mailboxFullStatus" | "customMailTip" | "externalMemberCount" | "totalMemberCount" | "maxMessageSize" | "deliveryRestriction" | "moderationStatus" | "recipientScope" | "recipientSuggestions"
+export type RecipientScopeType = "none" | "internal" | "external" | "externalPartner" | "externalNonPartner"
 export type TimeZoneStandard = "windows" | "iana"
 export type BodyType = "text" | "html"
 export type Importance = "low" | "normal" | "high"
@@ -53,7 +55,7 @@ export type MobileAppContentFileUploadState = "success" | "transientError" | "er
 export type WindowsDeviceType = "none" | "desktop" | "mobile" | "holographic" | "team"
 export type MicrosoftStoreForBusinessLicenseType = "offline" | "online"
 export type VppTokenAccountType = "business" | "education"
-export type ComplianceStatus = "unknown" | "notApplicable" | "compliant" | "remediated" | "nonCompliant" | "error" | "conflict"
+export type ComplianceStatus = "unknown" | "notApplicable" | "compliant" | "remediated" | "nonCompliant" | "error" | "conflict" | "notAssigned"
 export type MdmAppConfigKeyType = "stringType" | "integerType" | "realType" | "booleanType" | "tokenType"
 export type ActionState = "none" | "pending" | "canceled" | "active" | "done" | "failed" | "notSupported"
 export type ManagedDeviceOwnerType = "unknown" | "company" | "personal"
@@ -63,11 +65,14 @@ export type DeviceEnrollmentType = "unknown" | "userEnrollment" | "deviceEnrollm
 export type DeviceRegistrationState = "notRegistered" | "registered" | "revoked" | "keyConflict" | "approvalPending" | "certificateReset" | "notRegisteredPendingEnrollment" | "unknown"
 export type DeviceManagementExchangeAccessState = "none" | "unknown" | "allowed" | "blocked" | "quarantined"
 export type DeviceManagementExchangeAccessStateReason = "none" | "unknown" | "exchangeGlobalRule" | "exchangeIndividualRule" | "exchangeDeviceRule" | "exchangeUpgrade" | "exchangeMailboxPolicy" | "other" | "compliant" | "notCompliant" | "notEnrolled" | "unknownLocation" | "mfaRequired" | "azureADBlockDueToAccessPolicy" | "compromisedPassword" | "deviceNotKnownWithManagedApp"
-export type ManagedDevicePartnerReportedHealthState = "unknown" | "activated" | "deactivated" | "secured" | "lowSeverity" | "mediumSeverity" | "highSeverity" | "unresponsive"
+export type ManagedDevicePartnerReportedHealthState = "unknown" | "activated" | "deactivated" | "secured" | "lowSeverity" | "mediumSeverity" | "highSeverity" | "unresponsive" | "compromised" | "misconfigured"
 export type DeviceManagementSubscriptionState = "pending" | "active" | "warning" | "disabled" | "deleted" | "blocked" | "lockedOut"
 export type AppListType = "none" | "appsInListCompliant" | "appsNotInListCompliant"
 export type AndroidRequiredPasswordType = "deviceDefault" | "alphabetic" | "alphanumeric" | "alphanumericWithSymbols" | "lowSecurityBiometric" | "numeric" | "numericComplex" | "any"
 export type WebBrowserCookieSettings = "browserDefault" | "blockAlways" | "allowCurrentWebSite" | "allowFromWebsitesVisited" | "allowAlways"
+export type AndroidWorkProfileRequiredPasswordType = "deviceDefault" | "lowSecurityBiometric" | "required" | "atLeastNumeric" | "numericComplex" | "atLeastAlphabetic" | "atLeastAlphanumeric" | "alphanumericWithSymbols"
+export type AndroidWorkProfileCrossProfileDataSharingType = "deviceDefault" | "preventAny" | "allowPersonalToWork" | "noRestrictions"
+export type AndroidWorkProfileDefaultAppPermissionPolicyType = "deviceDefault" | "prompt" | "autoGrant" | "autoDeny"
 export type RatingAustraliaMoviesType = "allAllowed" | "allBlocked" | "general" | "parentalGuidance" | "mature" | "agesAbove15" | "agesAbove18"
 export type RatingAustraliaTelevisionType = "allAllowed" | "allBlocked" | "preschoolers" | "children" | "general" | "parentalGuidance" | "mature" | "agesAbove15" | "agesAbove15AdultViolence"
 export type RatingCanadaMoviesType = "allAllowed" | "allBlocked" | "general" | "parentalGuidance" | "agesAbove14" | "agesAbove18" | "restricted"
@@ -91,16 +96,17 @@ export type RequiredPasswordType = "deviceDefault" | "alphanumeric" | "numeric"
 export type IosNotificationAlertType = "deviceDefault" | "banner" | "modal" | "none"
 export type EditionUpgradeLicenseType = "productKey" | "licenseFile"
 export type Windows10EditionType = "windows10Enterprise" | "windows10EnterpriseN" | "windows10Education" | "windows10EducationN" | "windows10MobileEnterprise" | "windows10HolographicEnterprise" | "windows10Professional" | "windows10ProfessionalN" | "windows10ProfessionalEducation" | "windows10ProfessionalEducationN" | "windows10ProfessionalWorkstation" | "windows10ProfessionalWorkstationN"
+export type StateManagementSetting = "notConfigured" | "blocked" | "allowed"
 export type FirewallPreSharedKeyEncodingMethodType = "deviceDefault" | "none" | "utF8"
 export type FirewallCertificateRevocationListCheckMethodType = "deviceDefault" | "none" | "attempt" | "require"
 export type FirewallPacketQueueingMethodType = "deviceDefault" | "disabled" | "queueInbound" | "queueOutbound" | "queueBoth"
-export type StateManagementSetting = "notConfigured" | "blocked" | "allowed"
 export type AppLockerApplicationControlType = "notConfigured" | "enforceComponentsAndStoreApps" | "auditComponentsAndStoreApps" | "enforceComponentsStoreAppsAndSmartlocker" | "auditComponentsStoreAppsAndSmartlocker"
 export type ApplicationGuardBlockFileTransferType = "notConfigured" | "blockImageAndTextFile" | "blockImageFile" | "blockNone" | "blockTextFile"
 export type ApplicationGuardBlockClipboardSharingType = "notConfigured" | "blockBoth" | "blockHostToContainer" | "blockContainerToHost" | "blockNone"
 export type BitLockerEncryptionMethod = "aesCbc128" | "aesCbc256" | "xtsAes128" | "xtsAes256"
 export type DiagnosticDataSubmissionMode = "userDefined" | "none" | "basic" | "enhanced" | "full"
 export type EdgeCookiePolicy = "userDefined" | "allow" | "blockThirdParty" | "blockAll"
+export type VisibilitySetting = "notConfigured" | "hide" | "show"
 export type DefenderThreatAction = "deviceDefault" | "clean" | "quarantine" | "remove" | "allow" | "userDefined" | "block"
 export type WeeklySchedule = "userDefined" | "everyday" | "sunday" | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday"
 export type DefenderMonitorFileActivity = "userDefined" | "disable" | "monitorAllFiles" | "monitorIncomingFilesOnly" | "monitorOutgoingFilesOnly"
@@ -109,7 +115,6 @@ export type DefenderScanType = "userDefined" | "disabled" | "quick" | "full"
 export type DefenderCloudBlockLevelType = "notConfigured" | "high" | "highPlus" | "zeroTolerance"
 export type WindowsStartMenuAppListVisibilityType = "userDefined" | "collapse" | "remove" | "disableSettingsApp"
 export type WindowsStartMenuModeType = "userDefined" | "fullScreen" | "nonFullScreen"
-export type VisibilitySetting = "notConfigured" | "hide" | "show"
 export type WindowsSpotlightEnablementSettings = "notConfigured" | "disabled" | "enabled"
 export type AutomaticUpdateMode = "userDefined" | "notifyDownload" | "autoInstallAtMaintenanceTime" | "autoInstallAndRebootAtMaintenanceTime" | "autoInstallAndRebootAtScheduledTime" | "autoInstallAndRebootWithoutEndUserControl"
 export type SafeSearchFilterType = "userDefined" | "strict" | "moderate"
@@ -124,7 +129,7 @@ export type SiteSecurityLevel = "userDefined" | "low" | "mediumLow" | "medium" |
 export type WindowsUserAccountControlSettings = "userDefined" | "alwaysNotify" | "notifyOnAppChanges" | "notifyOnAppChangesWithoutDimming" | "neverNotify"
 export type MiracastChannel = "userDefined" | "one" | "two" | "three" | "four" | "five" | "six" | "seven" | "eight" | "nine" | "ten" | "eleven" | "thirtySix" | "forty" | "fortyFour" | "fortyEight" | "oneHundredFortyNine" | "oneHundredFiftyThree" | "oneHundredFiftySeven" | "oneHundredSixtyOne" | "oneHundredSixtyFive"
 export type WelcomeScreenMeetingInformation = "userDefined" | "showOrganizerAndTimeOnly" | "showOrganizerAndTimeAndSubject"
-export type DeviceComplianceActionType = "noAction" | "notification" | "block" | "retire" | "wipe" | "removeResourceAccessProfiles"
+export type DeviceComplianceActionType = "noAction" | "notification" | "block" | "retire" | "wipe" | "removeResourceAccessProfiles" | "pushNotification"
 export type DeviceThreatProtectionLevel = "unavailable" | "secured" | "low" | "medium" | "high" | "notSet"
 export type PolicyPlatformType = "android" | "iOS" | "macOS" | "windowsPhone81" | "windows81AndLater" | "windows10AndLater" | "androidWorkProfile" | "all"
 export type IosUpdatesInstallStatus = "success" | "available" | "idle" | "unknown" | "downloading" | "downloadFailed" | "downloadRequiresComputer" | "downloadInsufficientSpace" | "downloadInsufficientPower" | "downloadInsufficientNetwork" | "installing" | "installInsufficientSpace" | "installInsufficientPower" | "installPhoneCallInProgress" | "installFailed" | "notSupportedOperation" | "sharedDeviceUserLoggedInError"
@@ -132,7 +137,7 @@ export type DeviceManagementExchangeConnectorSyncType = "fullSync" | "deltaSync"
 export type MdmAuthority = "unknown" | "intune" | "sccm" | "office365"
 export type WindowsHelloForBusinessPinUsage = "allowed" | "required" | "disallowed"
 export type Enablement = "notConfigured" | "enabled" | "disabled"
-export type VppTokenState = "unknown" | "valid" | "expired" | "invalid"
+export type VppTokenState = "unknown" | "valid" | "expired" | "invalid" | "assignedToExternalMDM"
 export type VppTokenSyncStatus = "none" | "inProgress" | "completed" | "failed"
 export type DeviceManagementExchangeConnectorStatus = "none" | "connectionPending" | "connected" | "disconnected"
 export type DeviceManagementExchangeConnectorType = "onPremises" | "hosted" | "serviceToService" | "dedicated"
@@ -151,82 +156,96 @@ export type NotificationTemplateBrandingOptions = "none" | "includeCompanyLogo" 
 export type InstallState = "notApplicable" | "installed" | "failed" | "notInstalled" | "uninstallFailed" | "unknown"
 export type RemoteAssistanceOnboardingStatus = "notOnboarded" | "onboarding" | "onboarded"
 export type ApplicationType = "universal" | "desktop"
-export type DeviceEnrollmentFailureReason = "unknown" | "authentication" | "authorization" | "accountValidation" | "userValidation" | "deviceNotSupported" | "inMaintenance" | "badRequest" | "featureNotSupported" | "enrollmentRestrictionsEnforced" | "clientDisconnected"
+export type DeviceEnrollmentFailureReason = "unknown" | "authentication" | "authorization" | "accountValidation" | "userValidation" | "deviceNotSupported" | "inMaintenance" | "badRequest" | "featureNotSupported" | "enrollmentRestrictionsEnforced" | "clientDisconnected" | "userAbandonment"
 export type Status = "active" | "updated" | "deleted" | "ignored" | "unknownFutureValue"
+export type AlertFeedback = "unknown" | "truePositive" | "falsePositive" | "benignPositive" | "unknownFutureValue"
+export type AlertSeverity = "unknown" | "informational" | "low" | "medium" | "high" | "unknownFutureValue"
+export type AlertStatus = "unknown" | "newAlert" | "inProgress" | "resolved" | "dismissed" | "unknownFutureValue"
+export type ConnectionDirection = "unknown" | "inbound" | "outbound" | "unknownFutureValue"
+export type ConnectionStatus = "unknown" | "attempted" | "succeeded" | "blocked" | "failed" | "unknownFutureValue"
+export type EmailRole = "unknown" | "sender" | "recipient" | "unknownFutureValue"
+export type FileHashType = "unknown" | "sha1" | "sha256" | "md5" | "authenticodeHash256" | "lsHash" | "ctph" | "unknownFutureValue"
+export type LogonType = "unknown" | "interactive" | "remoteInteractive" | "network" | "batch" | "service" | "unknownFutureValue"
+export type ProcessIntegrityLevel = "unknown" | "untrusted" | "low" | "medium" | "high" | "system" | "unknownFutureValue"
+export type RegistryHive = "unknown" | "currentConfig" | "currentUser" | "localMachineSam" | "localMachineSecurity" | "localMachineSoftware" | "localMachineSystem" | "usersDefault" | "unknownFutureValue"
+export type RegistryOperation = "unknown" | "create" | "modify" | "delete" | "unknownFutureValue"
+export type RegistryValueType = "unknown" | "binary" | "dword" | "dwordLittleEndian" | "dwordBigEndian" | "expandSz" | "link" | "multiSz" | "none" | "qword" | "qwordlittleEndian" | "sz" | "unknownFutureValue"
+export type SecurityNetworkProtocol = "ip" | "icmp" | "igmp" | "ggp" | "ipv4" | "tcp" | "pup" | "udp" | "idp" | "ipv6" | "ipv6RoutingHeader" | "ipv6FragmentHeader" | "ipSecEncapsulatingSecurityPayload" | "ipSecAuthenticationHeader" | "icmpV6" | "ipv6NoNextHeader" | "ipv6DestinationOptions" | "nd" | "raw" | "ipx" | "spx" | "spxII" | "unknownFutureValue" | "unknown"
+export type UserAccountSecurityType = "unknown" | "standard" | "power" | "administrator" | "unknownFutureValue"
 
 export interface Entity {
 
-		        id: string
-	
+		id?: string
+
 }
 
 export interface Directory extends Entity {
 
-		        deletedItems?: DirectoryObject[]
-	
+		deletedItems?: DirectoryObject[]
+
 }
 
 export interface DirectoryObject extends Entity {
 
-		        deletedDateTime?: string
-	
+		deletedDateTime?: string
+
 }
 
 export interface Device extends DirectoryObject {
 
 	    /** true if the account is enabled; otherwise, false. Required. */
-		        accountEnabled?: boolean
-	
-		        alternativeSecurityIds: AlternativeSecurityId[]
-	
+		accountEnabled?: boolean
+
+		alternativeSecurityIds?: AlternativeSecurityId[]
+
 	    /** The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' Read-only. */
-		        approximateLastSignInDateTime?: string
-	
+		approximateLastSignInDateTime?: string
+
 	    /** Unique identifier set by Azure Device Registration Service at the time of registration. */
-		        deviceId?: string
-	
+		deviceId?: string
+
 	    /** For interal use only. Set to null. */
-		        deviceMetadata?: string
-	
+		deviceMetadata?: string
+
 	    /** For interal use only. */
-		        deviceVersion?: number
-	
+		deviceVersion?: number
+
 	    /** The display name for the device. Required. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** true if the device complies with Mobile Device Management (MDM) policies; otherwise, false. Read-only. */
-		        isCompliant?: boolean
-	
+		isCompliant?: boolean
+
 	    /** true if the device is managed by a Mobile Device Management (MDM) app; otherwise, false. */
-		        isManaged?: boolean
-	
+		isManaged?: boolean
+
 	    /** The last time at which the object was synced with the on-premises directory.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' Read-only. */
-		        onPremisesLastSyncDateTime?: string
-	
+		onPremisesLastSyncDateTime?: string
+
 	    /** true if this object is synced from an on-premises directory; false if this object was originally synced from an on-premises directory but is no longer synced; null if this object has never been synced from an on-premises directory (default). Read-only. */
-		        onPremisesSyncEnabled?: boolean
-	
+		onPremisesSyncEnabled?: boolean
+
 	    /** The type of operating system on the device. Required. */
-		        operatingSystem?: string
-	
+		operatingSystem?: string
+
 	    /** The version of the operating system on the device. Required. */
-		        operatingSystemVersion?: string
-	
+		operatingSystemVersion?: string
+
 	    /** For interal use only. Not nullable. */
-		        physicalIds: string[]
-	
+		physicalIds?: string[]
+
 	    /** Type of trust for the joined device. Read-only. Possible values: Workplace - indicates bring your own personal devicesAzureAd - Cloud only joined devicesServerAd - on-premises domain joined devices joined to Azure AD. For more details, see Introduction to device management in Azure Active Directory */
-		        trustType?: string
-	
+		trustType?: string
+
 	    /** The user that cloud joined the device or registered their personal device. The registered owner is set at the time of registration. Currently, there can be only one owner. Read-only. Nullable. */
-		        registeredOwners?: DirectoryObject[]
-	
+		registeredOwners?: DirectoryObject[]
+
 	    /** Collection of registered users of the device. For cloud joined devices and registered personal devices, registered users are set to the same value as registered owners at the time of registration. Read-only. Nullable. */
-		        registeredUsers?: DirectoryObject[]
-	
+		registeredUsers?: DirectoryObject[]
+
 	    /** The collection of open extensions defined for the device. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 }
 
 export interface Extension extends Entity {
@@ -236,1706 +255,1740 @@ export interface Extension extends Entity {
 export interface DirectoryRole extends DirectoryObject {
 
 	    /** The description for the directory role. Read-only. */
-		        description?: string
-	
+		description?: string
+
 	    /** The display name for the directory role. Read-only. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The id of the directoryRoleTemplate that this role is based on. The property must be specified when activating a directory role in a tenant with a POST operation. After the directory role has been activated, the property is read only. */
-		        roleTemplateId?: string
-	
+		roleTemplateId?: string
+
 	    /** Users that are members of this directory role. HTTP Methods: GET, POST, DELETE. Read-only. Nullable. */
-		        members?: DirectoryObject[]
-	
+		members?: DirectoryObject[]
+
 }
 
 export interface DirectoryRoleTemplate extends DirectoryObject {
 
 	    /** The description to set for the directory role. Read-only. */
-		        description?: string
-	
+		description?: string
+
 	    /** The display name to set for the directory role. Read-only. */
-		        displayName?: string
-	
+		displayName?: string
+
 }
 
 export interface Domain extends Entity {
 
 	    /** Indicates the configured authentication type for the domain. The value is either Managed or Federated. Managed indicates a cloud managed domain where Azure AD performs user authentication.Federated indicates authentication is federated with an identity provider such as the tenant's on-premises Active Directory via Active Directory Federation Services. Not nullable */
-		        authenticationType: string
-	
+		authenticationType?: string
+
 	    /** This property is always null except when the verify action is used. When the verify action is used, a domain entity is returned in the response. The availabilityStatus property of the domain entity in the response is either AvailableImmediately or EmailVerifiedDomainTakeoverScheduled. */
-		        availabilityStatus?: string
-	
+		availabilityStatus?: string
+
 	    /** The value of the property is false if the DNS record management of the domain has been delegated to Office 365. Otherwise, the value is true. Not nullable */
-		        isAdminManaged: boolean
-	
+		isAdminManaged?: boolean
+
 	    /** True if this is the default domain that is used for user creation. There is only one default domain per company. Not nullable */
-		        isDefault: boolean
-	
+		isDefault?: boolean
+
 	    /** True if this is the initial domain created by Microsoft Online Services (companyname.onmicrosoft.com). There is only one initial domain per company. Not nullable */
-		        isInitial: boolean
-	
+		isInitial?: boolean
+
 	    /** True if the domain is a verified root domain. Otherwise, false if the domain is a subdomain or unverified. Not nullable */
-		        isRoot: boolean
-	
+		isRoot?: boolean
+
 	    /** True if the domain has completed domain ownership verification. Not nullable */
-		        isVerified: boolean
-	
+		isVerified?: boolean
+
 	    /** The capabilities assigned to the domain.Can include 0, 1 or more of following values: Email, Sharepoint, EmailInternalRelayOnly, OfficeCommunicationsOnline, SharePointDefaultDomain, FullRedelegation, SharePointPublic, OrgIdAuthentication, Yammer, Intune The values which you can add/remove using Graph API include: Email, OfficeCommunicationsOnline, YammerNot nullable */
-		        supportedServices: string[]
-	
+		supportedServices?: string[]
+
 	    /** Status of asynchronous operations scheduled for the domain. */
-		        state?: DomainState
-	
+		state?: DomainState
+
 	    /** DNS records the customer adds to the DNS zone file of the domain before the domain can be used by Microsoft Online services.Read-only, Nullable */
-		        serviceConfigurationRecords?: DomainDnsRecord[]
-	
+		serviceConfigurationRecords?: DomainDnsRecord[]
+
 	    /** DNS records that the customer adds to the DNS zone file of the domain before the customer can complete domain ownership verification with Azure AD.Read-only, Nullable */
-		        verificationDnsRecords?: DomainDnsRecord[]
-	
+		verificationDnsRecords?: DomainDnsRecord[]
+
 	    /** Read-only, Nullable */
-		        domainNameReferences?: DirectoryObject[]
-	
+		domainNameReferences?: DirectoryObject[]
+
 }
 
 export interface DomainDnsRecord extends Entity {
 
 	    /** If false, this record must be configured by the customer at the DNS host for Microsoft Online Services to operate correctly with the domain. */
-		        isOptional: boolean
-	
+		isOptional?: boolean
+
 	    /** Value used when configuring the name of the DNS record at the DNS host. */
-		        label: string
-	
+		label?: string
+
 	    /** Indicates what type of DNS record this entity represents.The value can be one of the following: CName, Mx, Srv, TxtKey */
-		        recordType?: string
-	
+		recordType?: string
+
 	    /** Microsoft Online Service or feature that has a dependency on this DNS record.Can be one of the following values: null, Email, Sharepoint, EmailInternalRelayOnly, OfficeCommunicationsOnline, SharePointDefaultDomain, FullRedelegation, SharePointPublic, OrgIdAuthentication, Yammer, Intune */
-		        supportedService: string
-	
+		supportedService?: string
+
 	    /** Value to use when configuring the time-to-live (ttl) property of the DNS record at the DNS host. Not nullable */
-		        ttl: number
-	
+		ttl?: number
+
 }
 
 export interface DomainDnsCnameRecord extends DomainDnsRecord {
 
 	    /** The canonical name of the CNAME record. Used to configure the CNAME record at the DNS host. */
-		        canonicalName?: string
-	
+		canonicalName?: string
+
 }
 
 export interface DomainDnsMxRecord extends DomainDnsRecord {
 
 	    /** Value used when configuring the answer/destination/value of the MX record at the DNS host. */
-		        mailExchange: string
-	
+		mailExchange?: string
+
 	    /** Value used when configuring the Preference/Priority property of the MX record at the DNS host. */
-		        preference?: number
-	
+		preference?: number
+
 }
 
 export interface DomainDnsSrvRecord extends DomainDnsRecord {
 
 	    /** Value to use when configuring the Target property of the SRV record at the DNS host. */
-		        nameTarget?: string
-	
+		nameTarget?: string
+
 	    /** Value to use when configuring the port property of the SRV record at the DNS host. */
-		        port?: number
-	
+		port?: number
+
 	    /** Value to use when configuring the priority property of the SRV record at the DNS host. */
-		        priority?: number
-	
+		priority?: number
+
 	    /** Value to use when configuring the protocol property of the SRV record at the DNS host. */
-		        protocol?: string
-	
+		protocol?: string
+
 	    /** Value to use when configuring the service property of the SRV record at the DNS host. */
-		        service?: string
-	
+		service?: string
+
 	    /** Value to use when configuring the weight property of the SRV record at the DNS host. */
-		        weight?: number
-	
+		weight?: number
+
 }
 
 export interface DomainDnsTxtRecord extends DomainDnsRecord {
 
 	    /** Value used when configuring the text property at the DNS host. */
-		        text: string
-	
+		text?: string
+
 }
 
 export interface DomainDnsUnavailableRecord extends DomainDnsRecord {
 
 	    /** Provides the reason why the DomainDnsUnavailableRecord entity is returned. */
-		        description?: string
-	
+		description?: string
+
 }
 
 export interface LicenseDetails extends Entity {
 
 	    /** Information about the service plans assigned with the license. Read-only, Not nullable */
-		        servicePlans: ServicePlanInfo[]
-	
+		servicePlans?: ServicePlanInfo[]
+
 	    /** Unique identifier (GUID) for the service SKU. Equal to the skuId property on the related SubscribedSku object. Read-only */
-		        skuId?: string
-	
+		skuId?: string
+
 	    /** Unique SKU display name. Equal to the skuPartNumber on the related SubscribedSku object; for example: "AAD_Premium". Read-only */
-		        skuPartNumber?: string
-	
+		skuPartNumber?: string
+
 }
 
 export interface Group extends DirectoryObject {
 
-		        classification?: string
-	
+		classification?: string
+
 	    /** Timestamp of when the group was created. The value cannot be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. */
-		        createdDateTime?: string
-	
+		createdDateTime?: string
+
 	    /** An optional description for the group. */
-		        description?: string
-	
+		description?: string
+
 	    /** The display name for the group. This property is required when a group is created and it cannot be cleared during updates. Supports $filter and $orderby. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Specifies the type of group to create. Possible values are Unified to create an Office 365 group, or DynamicMembership for dynamic groups.  For all other group types, like security-enabled groups and email-enabled security groups, do not set this property. Supports $filter. */
-		        groupTypes: string[]
-	
+		groupTypes?: string[]
+
 	    /** The SMTP address for the group, for example, "serviceadmins@contoso.onmicrosoft.com". Read-only. Supports $filter. */
-		        mail?: string
-	
+		mail?: string
+
 	    /** Specifies whether the group is mail-enabled. If the securityEnabled property is also true, the group is a mail-enabled security group; otherwise, the group is a Microsoft Exchange distribution group. */
-		        mailEnabled?: boolean
-	
+		mailEnabled?: boolean
+
 	    /** The mail alias for the group, unique in the organization. This property must be specified when a group is created. Supports $filter. */
-		        mailNickname?: string
-	
+		mailNickname?: string
+
 	    /** Indicates the last time at which the group was synced with the on-premises directory.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. Supports $filter. */
-		        onPremisesLastSyncDateTime?: string
-	
+		onPremisesLastSyncDateTime?: string
+
+		onPremisesProvisioningErrors?: OnPremisesProvisioningError[]
+
 	    /** Contains the on-premises security identifier (SID) for the group that was synchronized from on-premises to the cloud. Read-only. */
-		        onPremisesSecurityIdentifier?: string
-	
+		onPremisesSecurityIdentifier?: string
+
 	    /** true if this group is synced from an on-premises directory; false if this group was originally synced from an on-premises directory but is no longer synced; null if this object has never been synced from an on-premises directory (default). Read-only. Supports $filter. */
-		        onPremisesSyncEnabled?: boolean
-	
+		onPremisesSyncEnabled?: boolean
+
 	    /** The any operator is required for filter expressions on multi-valued properties. Read-only. Not nullable. Supports $filter. */
-		        proxyAddresses: string[]
-	
+		proxyAddresses?: string[]
+
 	    /** Timestamp of when the group was last renewed. This cannot be modified directly and is only updated via the renew service action. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. */
-		        renewedDateTime?: string
-	
+		renewedDateTime?: string
+
 	    /** Specifies whether the group is a security group. If the mailEnabled property is also true, the group is a mail-enabled security group; otherwise it is a security group. Must be false for Office 365 groups. Supports $filter. */
-		        securityEnabled?: boolean
-	
+		securityEnabled?: boolean
+
 	    /** Specifies the visibility of an Office 365 group. Possible values are: Private, Public, or empty (which is interpreted as Public). */
-		        visibility?: string
-	
+		visibility?: string
+
 	    /** Default is false. Indicates if people external to the organization can send messages to the group. */
-		        allowExternalSenders?: boolean
-	
+		allowExternalSenders?: boolean
+
 	    /** Default is false. Indicates if new members added to the group will be auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group. */
-		        autoSubscribeNewMembers?: boolean
-	
+		autoSubscribeNewMembers?: boolean
+
 	    /** Default value is true. Indicates whether the current user is subscribed to receive email conversations. */
-		        isSubscribedByMail?: boolean
-	
+		isSubscribedByMail?: boolean
+
 	    /** Count of posts that the current  user has not seen since his last visit. */
-		        unseenCount?: number
-	
+		unseenCount?: number
+
 	    /** Users and groups that are members of this group. HTTP Methods: GET (supported for all groups), POST (supported for Office 365 groups, security groups and mail-enabled security groups), DELETE (supported for Office 365 groups and security groups) Nullable. */
-		        members?: DirectoryObject[]
-	
+		members?: DirectoryObject[]
+
 	    /** Groups that this group is a member of. HTTP Methods: GET (supported for all groups). Read-only. Nullable. */
-		        memberOf?: DirectoryObject[]
-	
+		memberOf?: DirectoryObject[]
+
 	    /** The user (or application) that created the group. NOTE: This is not set if the user is an administrator. Read-only. */
-		        createdOnBehalfOf?: DirectoryObject
-	
+		createdOnBehalfOf?: DirectoryObject
+
 	    /** The owners of the group. The owners are a set of non-admin users who are allowed to modify this object. Limited to 10 owners. HTTP Methods: GET (supported for all groups), POST (supported for Office 365 groups, security groups and mail-enabled security groups), DELETE (supported for Office 365 groups and security groups). Nullable. */
-		        owners?: DirectoryObject[]
-	
+		owners?: DirectoryObject[]
+
 	    /** Read-only. Nullable. */
-		        settings?: GroupSetting[]
-	
+		settings?: GroupSetting[]
+
 	    /** The collection of open extensions defined for the group. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 	    /** The group's conversation threads. Nullable. */
-		        threads?: ConversationThread[]
-	
+		threads?: ConversationThread[]
+
 	    /** The group's calendar. Read-only. */
-		        calendar?: Calendar
-	
+		calendar?: Calendar
+
 	    /** The calendar view for the calendar. Read-only. */
-		        calendarView?: Event[]
-	
+		calendarView?: Event[]
+
 	    /** The group's calendar events. */
-		        events?: Event[]
-	
+		events?: Event[]
+
 	    /** The group's conversations. */
-		        conversations?: Conversation[]
-	
+		conversations?: Conversation[]
+
 	    /** The group's profile photo */
-		        photo?: ProfilePhoto
-	
+		photo?: ProfilePhoto
+
 	    /** The profile photos owned by the group. Read-only. Nullable. */
-		        photos?: ProfilePhoto[]
-	
+		photos?: ProfilePhoto[]
+
 	    /** The list of users or groups that are allowed to create post's or calendar events in this group. If this list is non-empty then only users or groups listed here are allowed to post. */
-		        acceptedSenders?: DirectoryObject[]
-	
+		acceptedSenders?: DirectoryObject[]
+
 	    /** The list of users or groups that are not allowed to create posts or calendar events in this group. Nullable */
-		        rejectedSenders?: DirectoryObject[]
-	
+		rejectedSenders?: DirectoryObject[]
+
 	    /** The group's drive. Read-only. */
-		        drive?: Drive
-	
-		        drives?: Drive[]
-	
+		drive?: Drive
+
+		drives?: Drive[]
+
 	    /** The list of SharePoint sites in this group. Access the default site with /sites/root. */
-		        sites?: Site[]
-	
+		sites?: Site[]
+
 	    /** Entry-point to Planner resource that might exist for a Unified Group. */
-		        planner?: PlannerGroup
-	
+		planner?: PlannerGroup
+
 	    /** Read-only. */
-		        onenote?: Onenote
-	
-		        groupLifecyclePolicies?: GroupLifecyclePolicy[]
-	
+		onenote?: Onenote
+
+		groupLifecyclePolicies?: GroupLifecyclePolicy[]
+
 }
 
 export interface GroupSetting extends Entity {
 
 	    /** Display name of this group of settings, which comes from the associated template. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Unique identifier for the template used to create this group of settings. Read-only. */
-		        templateId?: string
-	
+		templateId?: string
+
 	    /** Collection of name value pairs. Must contain and set all the settings defined in the template. */
-		        values: SettingValue[]
-	
+		values?: SettingValue[]
+
 }
 
 export interface ConversationThread extends Entity {
 
 	    /** The To: recipients for the thread. */
-		        toRecipients: Recipient[]
-	
+		toRecipients?: Recipient[]
+
 	    /** The topic of the conversation. This property can be set when the conversation is created, but it cannot be updated. */
-		        topic: string
-	
+		topic?: string
+
 	    /** Indicates whether any of the posts within this thread has at least one attachment. */
-		        hasAttachments: boolean
-	
+		hasAttachments?: boolean
+
 	    /** The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        lastDeliveredDateTime: string
-	
+		lastDeliveredDateTime?: string
+
 	    /** All the users that sent a message to this thread. */
-		        uniqueSenders: string[]
-	
+		uniqueSenders?: string[]
+
 	    /** The Cc: recipients for the thread. */
-		        ccRecipients: Recipient[]
-	
+		ccRecipients?: Recipient[]
+
 	    /** A short summary from the body of the latest post in this converstaion. */
-		        preview: string
-	
+		preview?: string
+
 	    /** Indicates if the thread is locked. */
-		        isLocked: boolean
-	
+		isLocked?: boolean
+
 	    /** Read-only. Nullable. */
-		        posts?: Post[]
-	
+		posts?: Post[]
+
 }
 
 export interface Calendar extends Entity {
 
 	    /** The calendar name. */
-		        name?: string
-	
+		name?: string
+
 	    /** Specifies the color theme to distinguish the calendar from other calendars in a UI. The property values are: LightBlue=0, LightGreen=1, LightOrange=2, LightGray=3, LightYellow=4, LightTeal=5, LightPink=6, LightBrown=7, LightRed=8, MaxColor=9, Auto=-1 */
-		        color?: CalendarColor
-	
+		color?: CalendarColor
+
 	    /** Identifies the version of the calendar object. Every time the calendar is changed, changeKey changes as well. This allows Exchange to apply changes to the correct version of the object. Read-only. */
-		        changeKey?: string
-	
+		changeKey?: string
+
 	    /** True if the user has the permission to share the calendar, false otherwise. Only the user who created the calendar can share it. */
-		        canShare?: boolean
-	
+		canShare?: boolean
+
 	    /** True if the user can read calendar items that have been marked private, false otherwise. */
-		        canViewPrivateItems?: boolean
-	
+		canViewPrivateItems?: boolean
+
 	    /** True if the user can write to the calendar, false otherwise. This property is true for the user who created the calendar. This property is also true for a user who has been shared a calendar and granted write access. */
-		        canEdit?: boolean
-	
+		canEdit?: boolean
+
 	    /** If set, this represents the user who created or added the calendar. For a calendar that the user created or added, the owner property is set to the user. For a calendar shared with the user, the owner property is set to the person who shared that calendar with the user. */
-		        owner?: EmailAddress
-	
+		owner?: EmailAddress
+
 	    /** The events in the calendar. Navigation property. Read-only. */
-		        events?: Event[]
-	
+		events?: Event[]
+
 	    /** The calendar view for the calendar. Navigation property. Read-only. */
-		        calendarView?: Event[]
-	
+		calendarView?: Event[]
+
 	    /** The collection of single-value extended properties defined for the calendar. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the calendar. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface OutlookItem extends Entity {
 
-		        createdDateTime?: string
-	
-		        lastModifiedDateTime?: string
-	
-		        changeKey?: string
-	
-		        categories?: string[]
-	
+		createdDateTime?: string
+
+		lastModifiedDateTime?: string
+
+		changeKey?: string
+
+		categories?: string[]
+
 }
 
 export interface Event extends OutlookItem {
 
 	    /** The start time zone that was set when the event was created. A value of tzone://Microsoft/Custom indicates that a legacy custom time zone was set in desktop Outlook. */
-		        originalStartTimeZone?: string
-	
+		originalStartTimeZone?: string
+
 	    /** The end time zone that was set when the event was created. A value of tzone://Microsoft/Custom indicates that a legacy custom time zone was set in desktop Outlook. */
-		        originalEndTimeZone?: string
-	
+		originalEndTimeZone?: string
+
 	    /** Indicates the type of response sent in response to an event message. */
-		        responseStatus?: ResponseStatus
-	
+		responseStatus?: ResponseStatus
+
 	    /** A unique identifier that is shared by all instances of an event across different calendars. */
-		        iCalUId?: string
-	
+		iCalUId?: string
+
 	    /** The number of minutes before the event start time that the reminder alert occurs. */
-		        reminderMinutesBeforeStart?: number
-	
+		reminderMinutesBeforeStart?: number
+
 	    /** Set to true if an alert is set to remind the user of the event. */
-		        isReminderOn?: boolean
-	
+		isReminderOn?: boolean
+
 	    /** Set to true if the event has attachments. */
-		        hasAttachments?: boolean
-	
+		hasAttachments?: boolean
+
 	    /** The text of the event's subject line. */
-		        subject?: string
-	
+		subject?: string
+
 	    /** The body of the message associated with the event. It can be in HTML or text format. */
-		        body?: ItemBody
-	
+		body?: ItemBody
+
 	    /** The preview of the message associated with the event. It is in text format. */
-		        bodyPreview?: string
-	
+		bodyPreview?: string
+
 	    /** The importance of the event. Possible values are: low, normal, high. */
-		        importance?: Importance
-	
+		importance?: Importance
+
 	    /** Possible values are: normal, personal, private, confidential. */
-		        sensitivity?: Sensitivity
-	
+		sensitivity?: Sensitivity
+
 	    /** The date, time, and time zone that the event starts. */
-		        start?: DateTimeTimeZone
-	
+		start?: DateTimeTimeZone
+
 	    /** The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        originalStart?: string
-	
+		originalStart?: string
+
 	    /** The date, time, and time zone that the event ends. */
-		        end?: DateTimeTimeZone
-	
+		end?: DateTimeTimeZone
+
 	    /** The location of the event. */
-		        location?: Location
-	
+		location?: Location
+
 	    /** The locations where the event is held or attended from. The location and locations properties always correspond with each other. If you update the location property, any prior locations in the locations collection would be removed and replaced by the new location value. */
-		        locations?: Location[]
-	
+		locations?: Location[]
+
 	    /** Set to true if the event lasts all day. */
-		        isAllDay?: boolean
-	
+		isAllDay?: boolean
+
 	    /** Set to true if the event has been canceled. */
-		        isCancelled?: boolean
-	
+		isCancelled?: boolean
+
 	    /** Set to true if the message sender is also the organizer. */
-		        isOrganizer?: boolean
-	
+		isOrganizer?: boolean
+
 	    /** The recurrence pattern for the event. */
-		        recurrence?: PatternedRecurrence
-	
+		recurrence?: PatternedRecurrence
+
 	    /** Set to true if the sender would like a response when the event is accepted or declined. */
-		        responseRequested?: boolean
-	
+		responseRequested?: boolean
+
 	    /** The ID for the recurring series master item, if this event is part of a recurring series. */
-		        seriesMasterId?: string
-	
+		seriesMasterId?: string
+
 	    /** The status to show. Possible values are: free, tentative, busy, oof, workingElsewhere, unknown. */
-		        showAs?: FreeBusyStatus
-	
+		showAs?: FreeBusyStatus
+
 	    /** The event type. Possible values are: singleInstance, occurrence, exception, seriesMaster. Read-only. */
-		        type?: EventType
-	
+		type?: EventType
+
 	    /** The collection of attendees for the event. */
-		        attendees?: Attendee[]
-	
+		attendees?: Attendee[]
+
 	    /** The organizer of the event. */
-		        organizer?: Recipient
-	
+		organizer?: Recipient
+
 	    /** The URL to open the event in Outlook Web App.The event will open in the browser if you are logged in to your mailbox via Outlook Web App. You will be prompted to login if you are not already logged in with the browser.This URL can be accessed from within an iFrame. */
-		        webLink?: string
-	
+		webLink?: string
+
 	    /** A URL for an online meeting. */
-		        onlineMeetingUrl?: string
-	
+		onlineMeetingUrl?: string
+
 	    /** The calendar that contains the event. Navigation property. Read-only. */
-		        calendar?: Calendar
-	
+		calendar?: Calendar
+
 	    /** The instances of the event. Navigation property. Read-only. Nullable. */
-		        instances?: Event[]
-	
+		instances?: Event[]
+
 	    /** The collection of open extensions defined for the event. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 	    /** The collection of fileAttachment and itemAttachment attachments for the event. Navigation property. Read-only. Nullable. */
-		        attachments?: Attachment[]
-	
+		attachments?: Attachment[]
+
 	    /** The collection of single-value extended properties defined for the event. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the event. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface Conversation extends Entity {
 
 	    /** The topic of the conversation. This property can be set when the conversation is created, but it cannot be updated. */
-		        topic: string
-	
+		topic?: string
+
 	    /** Indicates whether any of the posts within this Conversation has at least one attachment. */
-		        hasAttachments: boolean
-	
+		hasAttachments?: boolean
+
 	    /** The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        lastDeliveredDateTime: string
-	
+		lastDeliveredDateTime?: string
+
 	    /** All the users that sent a message to this Conversation. */
-		        uniqueSenders: string[]
-	
+		uniqueSenders?: string[]
+
 	    /** A short summary from the body of the latest post in this converstaion. */
-		        preview: string
-	
+		preview?: string
+
 	    /** A collection of all the conversation threads in the conversation. A navigation property. Read-only. Nullable. */
-		        threads?: ConversationThread[]
-	
+		threads?: ConversationThread[]
+
 }
 
 export interface ProfilePhoto extends Entity {
 
 	    /** The height of the photo. Read-only. */
-		        height?: number
-	
+		height?: number
+
 	    /** The width of the photo. Read-only. */
-		        width?: number
-	
+		width?: number
+
 }
 
 export interface BaseItem extends Entity {
 
 	    /** Identity of the user, device, or application which created the item. Read-only. */
-		        createdBy?: IdentitySet
-	
+		createdBy?: IdentitySet
+
 	    /** Date and time of item creation. Read-only. */
-		        createdDateTime: string
-	
-		        description?: string
-	
+		createdDateTime?: string
+
+		description?: string
+
 	    /** ETag for the item. Read-only. */
-		        eTag?: string
-	
+		eTag?: string
+
 	    /** Identity of the user, device, and application which last modified the item. Read-only. */
-		        lastModifiedBy?: IdentitySet
-	
+		lastModifiedBy?: IdentitySet
+
 	    /** Date and time the item was last modified. Read-only. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The name of the item. Read-write. */
-		        name?: string
-	
+		name?: string
+
 	    /** Parent information, if the item has a parent. Read-write. */
-		        parentReference?: ItemReference
-	
+		parentReference?: ItemReference
+
 	    /** URL that displays the resource in the browser. Read-only. */
-		        webUrl?: string
-	
-		        createdByUser?: User
-	
-		        lastModifiedByUser?: User
-	
+		webUrl?: string
+
+		createdByUser?: User
+
+		lastModifiedByUser?: User
+
 }
 
 export interface Drive extends BaseItem {
 
 	    /** Describes the type of drive represented by this resource. OneDrive personal drives will return personal. OneDrive for Business will return business. SharePoint document libraries will return documentLibrary. Read-only. */
-		        driveType?: string
-	
+		driveType?: string
+
 	    /** Optional. The user account that owns the drive. Read-only. */
-		        owner?: IdentitySet
-	
+		owner?: IdentitySet
+
 	    /** Optional. Information about the drive's storage space quota. Read-only. */
-		        quota?: Quota
-	
-		        sharePointIds?: SharepointIds
-	
+		quota?: Quota
+
+		sharePointIds?: SharepointIds
+
 	    /** If present, indicates that this is a system-managed drive. Read-only. */
-		        system?: SystemFacet
-	
+		system?: SystemFacet
+
 	    /** All items contained in the drive. Read-only. Nullable. */
-		        items?: DriveItem[]
-	
-		        list?: List
-	
+		items?: DriveItem[]
+
+		list?: List
+
 	    /** The root folder of the drive. Read-only. */
-		        root?: DriveItem
-	
+		root?: DriveItem
+
 	    /** Collection of common folders available in OneDrive. Read-only. Nullable. */
-		        special?: DriveItem[]
-	
+		special?: DriveItem[]
+
 }
 
 export interface Site extends BaseItem {
 
 	    /** The full title for the site. Read-only. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** If present, indicates that this is the root site in the site collection. Read-only. */
-		        root?: Root
-	
+		root?: Root
+
 	    /** Returns identifiers useful for SharePoint REST compatibility. Read-only. */
-		        sharepointIds?: SharepointIds
-	
+		sharepointIds?: SharepointIds
+
 	    /** Provides details about the site's site collection. Available only on the root site. Read-only. */
-		        siteCollection?: SiteCollection
-	
+		siteCollection?: SiteCollection
+
 	    /** The collection of column definitions reusable across lists under this site. */
-		        columns?: ColumnDefinition[]
-	
+		columns?: ColumnDefinition[]
+
 	    /** The collection of content types defined for this site. */
-		        contentTypes?: ContentType[]
-	
+		contentTypes?: ContentType[]
+
 	    /** The default drive (document library) for this site. */
-		        drive?: Drive
-	
+		drive?: Drive
+
 	    /** The collection of drives (document libraries) under this site. */
-		        drives?: Drive[]
-	
+		drives?: Drive[]
+
 	    /** Used to address any item contained in this site. This collection cannot be enumerated. */
-		        items?: BaseItem[]
-	
+		items?: BaseItem[]
+
 	    /** The collection of lists under this site. */
-		        lists?: List[]
-	
+		lists?: List[]
+
 	    /** The collection of the sub-sites under this site. */
-		        sites?: Site[]
-	
+		sites?: Site[]
+
 	    /** Calls the OneNote service for notebook related operations. */
-		        onenote?: Onenote
-	
+		onenote?: Onenote
+
 }
 
 export interface PlannerGroup extends Entity {
 
 	    /** Read-only. Nullable. Returns the plannerPlans owned by the group. */
-		        plans?: PlannerPlan[]
-	
+		plans?: PlannerPlan[]
+
 }
 
 export interface Onenote extends Entity {
 
-		        notebooks?: Notebook[]
-	
-		        sections?: OnenoteSection[]
-	
-		        sectionGroups?: SectionGroup[]
-	
-		        pages?: OnenotePage[]
-	
-		        resources?: OnenoteResource[]
-	
-		        operations?: OnenoteOperation[]
-	
+		notebooks?: Notebook[]
+
+		sections?: OnenoteSection[]
+
+		sectionGroups?: SectionGroup[]
+
+		pages?: OnenotePage[]
+
+		resources?: OnenoteResource[]
+
+		operations?: OnenoteOperation[]
+
 }
 
 export interface GroupLifecyclePolicy extends Entity {
 
 	    /** Number of days before a group expires and needs to be renewed. Once renewed, the group expiration is extended by the number of days defined. */
-		        groupLifetimeInDays?: number
-	
+		groupLifetimeInDays?: number
+
 	    /** The group type for which the expiration policy applies. Possible values are All, Selected or None. */
-		        managedGroupTypes?: string
-	
+		managedGroupTypes?: string
+
 	    /** List of email address to send notifications for groups without owners. Multiple email address can be defined by separating email address with a semicolon. */
-		        alternateNotificationEmails?: string
-	
+		alternateNotificationEmails?: string
+
 }
 
 export interface Contract extends DirectoryObject {
 
-		        contractType?: string
-	
-		        customerId?: string
-	
-		        defaultDomainName?: string
-	
-		        displayName?: string
-	
+		contractType?: string
+
+		customerId?: string
+
+		defaultDomainName?: string
+
+		displayName?: string
+
 }
 
 export interface SubscribedSku extends Entity {
 
 	    /** For example, "Enabled". */
-		        capabilityStatus?: string
-	
+		capabilityStatus?: string
+
 	    /** The number of licenses that have been assigned. */
-		        consumedUnits?: number
-	
+		consumedUnits?: number
+
 	    /** Information about the number and status of prepaid licenses. */
-		        prepaidUnits?: LicenseUnitsDetail
-	
+		prepaidUnits?: LicenseUnitsDetail
+
 	    /** Information about the service plans that are available with the SKU. Not nullable */
-		        servicePlans: ServicePlanInfo[]
-	
+		servicePlans?: ServicePlanInfo[]
+
 	    /** The unique identifier (GUID) for the service SKU. */
-		        skuId?: string
-	
+		skuId?: string
+
 	    /** The SKU part number; for example: "AAD_PREMIUM" or "RMSBASIC". */
-		        skuPartNumber?: string
-	
+		skuPartNumber?: string
+
 	    /** For example, "User" or "Company". */
-		        appliesTo?: string
-	
+		appliesTo?: string
+
 }
 
 export interface Organization extends DirectoryObject {
 
 	    /** The collection of service plans associated with the tenant. Not nullable. */
-		        assignedPlans: AssignedPlan[]
-	
-		        businessPhones: string[]
-	
+		assignedPlans?: AssignedPlan[]
+
+		businessPhones?: string[]
+
 	    /** City name of the address for the organization */
-		        city?: string
-	
+		city?: string
+
 	    /** Country/region name of the address for the organization */
-		        country?: string
-	
+		country?: string
+
 	    /** Country/region abbreviation for the organization */
-		        countryLetterCode?: string
-	
+		countryLetterCode?: string
+
 	    /** The display name for the tenant. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Not nullable. */
-		        marketingNotificationEmails: string[]
-	
-		        onPremisesLastSyncDateTime?: string
-	
-		        onPremisesSyncEnabled?: boolean
-	
+		marketingNotificationEmails?: string[]
+
+		onPremisesLastSyncDateTime?: string
+
+		onPremisesSyncEnabled?: boolean
+
 	    /** Postal code of the address for the organization */
-		        postalCode?: string
-	
+		postalCode?: string
+
 	    /** The preferred language for the organization. Should follow ISO 639-1 Code; for example "en". */
-		        preferredLanguage?: string
-	
+		preferredLanguage?: string
+
 	    /** The privacy profile of an organization. */
-		        privacyProfile?: PrivacyProfile
-	
+		privacyProfile?: PrivacyProfile
+
 	    /** Not nullable. */
-		        provisionedPlans: ProvisionedPlan[]
-	
-		        securityComplianceNotificationMails: string[]
-	
-		        securityComplianceNotificationPhones: string[]
-	
+		provisionedPlans?: ProvisionedPlan[]
+
+		securityComplianceNotificationMails?: string[]
+
+		securityComplianceNotificationPhones?: string[]
+
 	    /** State name of the address for the organization */
-		        state?: string
-	
+		state?: string
+
 	    /** Street name of the address for organization */
-		        street?: string
-	
+		street?: string
+
 	    /** Not nullable. */
-		        technicalNotificationMails: string[]
-	
+		technicalNotificationMails?: string[]
+
 	    /** The collection of domains associated with this tenant. Not nullable. */
-		        verifiedDomains: VerifiedDomain[]
-	
+		verifiedDomains?: VerifiedDomain[]
+
 	    /** Mobile device management authority. Possible values are: unknown, intune, sccm, office365. */
-		        mobileDeviceManagementAuthority: MdmAuthority
-	
+		mobileDeviceManagementAuthority?: MdmAuthority
+
 	    /** The collection of open extensions defined for the organization. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 }
 
 export interface User extends DirectoryObject {
 
 	    /** true if the account is enabled; otherwise, false. This property is required when a user is created. Supports $filter. */
-		        accountEnabled?: boolean
-	
-		        ageGroup?: string
-	
+		accountEnabled?: boolean
+
+		ageGroup?: string
+
 	    /** The licenses that are assigned to the user. Not nullable. */
-		        assignedLicenses: AssignedLicense[]
-	
+		assignedLicenses?: AssignedLicense[]
+
 	    /** The plans that are assigned to the user. Read-only. Not nullable. */
-		        assignedPlans: AssignedPlan[]
-	
+		assignedPlans?: AssignedPlan[]
+
 	    /** The telephone numbers for the user. NOTE: Although this is a string collection, only one number can be set for this property. */
-		        businessPhones: string[]
-	
+		businessPhones?: string[]
+
 	    /** The city in which the user is located. Supports $filter. */
-		        city?: string
-	
+		city?: string
+
 	    /** The company name which the user is associated. Read-only. */
-		        companyName?: string
-	
-		        consentProvidedForMinor?: string
-	
-	    /** The country/region in which the user is located; for example, “US” or “UK”. Supports $filter. */
-		        country?: string
-	
+		companyName?: string
+
+		consentProvidedForMinor?: string
+
+	    /** The country/region in which the user is located; for example, "US" or "UK". Supports $filter. */
+		country?: string
+
 	    /** The name for the department in which the user works. Supports $filter. */
-		        department?: string
-	
+		department?: string
+
 	    /** The name displayed in the address book for the user. This is usually the combination of the user's first name, middle initial and last name. This property is required when a user is created and it cannot be cleared during updates. Supports $filter and $orderby. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The given name (first name) of the user. Supports $filter. */
-		        givenName?: string
-	
-		        imAddresses?: string[]
-	
-	    /** The user’s job title. Supports $filter. */
-		        jobTitle?: string
-	
-		        legalAgeGroupClassification?: string
-	
+		givenName?: string
+
+		imAddresses?: string[]
+
+	    /** The user's job title. Supports $filter. */
+		jobTitle?: string
+
+		legalAgeGroupClassification?: string
+
 	    /** The SMTP address for the user, for example, "jeff@contoso.onmicrosoft.com". Read-Only. Supports $filter. */
-		        mail?: string
-	
+		mail?: string
+
 	    /** The mail alias for the user. This property must be specified when a user is created. Supports $filter. */
-		        mailNickname?: string
-	
+		mailNickname?: string
+
 	    /** The primary cellular telephone number for the user. */
-		        mobilePhone?: string
-	
-	    /** This property is used to associate an on-premises Active Directory user account to their Azure AD user object. This property must be specified when creating a new user account in the Graph if you are using a federated domain for the user’s userPrincipalName (UPN) property. Important: The $ and  characters cannot be used when specifying this property. Supports $filter. */
-		        onPremisesImmutableId?: string
-	
+		mobilePhone?: string
+
+		onPremisesExtensionAttributes?: OnPremisesExtensionAttributes
+
+	    /** This property is used to associate an on-premises Active Directory user account to their Azure AD user object. This property must be specified when creating a new user account in the Graph if you are using a federated domain for the user's userPrincipalName (UPN) property. Important: The $ and  characters cannot be used when specifying this property. Supports $filter. */
+		onPremisesImmutableId?: string
+
 	    /** Indicates the last time at which the object was synced with the on-premises directory; for example: "2013-02-16T03:04:54Z". The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. */
-		        onPremisesLastSyncDateTime?: string
-	
+		onPremisesLastSyncDateTime?: string
+
+		onPremisesProvisioningErrors?: OnPremisesProvisioningError[]
+
 	    /** Contains the on-premises security identifier (SID) for the user that was synchronized from on-premises to the cloud. Read-only. */
-		        onPremisesSecurityIdentifier?: string
-	
+		onPremisesSecurityIdentifier?: string
+
 	    /** true if this object is synced from an on-premises directory; false if this object was originally synced from an on-premises directory but is no longer synced; null if this object has never been synced from an on-premises directory (default). Read-only */
-		        onPremisesSyncEnabled?: boolean
-	
-	    /** Specifies password policies for the user. This value is an enumeration with one possible value being “DisableStrongPassword”, which allows weaker passwords than the default policy to be specified. “DisablePasswordExpiration” can also be specified. The two may be specified together; for example: "DisablePasswordExpiration, DisableStrongPassword". */
-		        passwordPolicies?: string
-	
-	    /** Specifies the password profile for the user. The profile contains the user’s password. This property is required when a user is created. The password in the profile must satisfy minimum requirements as specified by the passwordPolicies property. By default, a strong password is required. */
-		        passwordProfile?: PasswordProfile
-	
+		onPremisesSyncEnabled?: boolean
+
+		onPremisesDomainName?: string
+
+		onPremisesSamAccountName?: string
+
+		onPremisesUserPrincipalName?: string
+
+	    /** Specifies password policies for the user. This value is an enumeration with one possible value being "DisableStrongPassword", which allows weaker passwords than the default policy to be specified. "DisablePasswordExpiration" can also be specified. The two may be specified together; for example: "DisablePasswordExpiration, DisableStrongPassword". */
+		passwordPolicies?: string
+
+	    /** Specifies the password profile for the user. The profile contains the user's password. This property is required when a user is created. The password in the profile must satisfy minimum requirements as specified by the passwordPolicies property. By default, a strong password is required. */
+		passwordProfile?: PasswordProfile
+
 	    /** The office location in the user's place of business. */
-		        officeLocation?: string
-	
+		officeLocation?: string
+
 	    /** The postal code for the user's postal address. The postal code is specific to the user's country/region. In the United States of America, this attribute contains the ZIP code. */
-		        postalCode?: string
-	
+		postalCode?: string
+
 	    /** The preferred language for the user. Should follow ISO 639-1 Code; for example "en-US". */
-		        preferredLanguage?: string
-	
+		preferredLanguage?: string
+
 	    /** The plans that are provisioned for the user. Read-only. Not nullable. */
-		        provisionedPlans: ProvisionedPlan[]
-	
+		provisionedPlans?: ProvisionedPlan[]
+
 	    /** For example: ["SMTP: bob@contoso.com", "smtp: bob@sales.contoso.com"] The any operator is required for filter expressions on multi-valued properties. Read-only, Not nullable. Supports $filter. */
-		        proxyAddresses: string[]
-	
+		proxyAddresses?: string[]
+
 	    /** The state or province in the user's address. Supports $filter. */
-		        state?: string
-	
+		state?: string
+
 	    /** The street address of the user's place of business. */
-		        streetAddress?: string
-	
+		streetAddress?: string
+
 	    /** The user's surname (family name or last name). Supports $filter. */
-		        surname?: string
-	
+		surname?: string
+
 	    /** A two letter country code (ISO standard 3166). Required for users that will be assigned licenses due to legal requirement to check for availability of services in countries.  Examples include: "US", "JP", and "GB". Not nullable. Supports $filter. */
-		        usageLocation?: string
-	
-	    /** The user principal name (UPN) of the user. The UPN is an Internet-style login name for the user based on the Internet standard RFC 822. By convention, this should map to the user's email name. The general format is alias@domain, where domain must be present in the tenant’s collection of verified domains. This property is required when a user is created. The verified domains for the tenant can be accessed from the verifiedDomains property of organization. Supports $filter and $orderby. */
-		        userPrincipalName?: string
-	
-	    /** A string value that can be used to classify user types in your directory, such as “Member” and “Guest”. Supports $filter. */
-		        userType?: string
-	
+		usageLocation?: string
+
+	    /** The user principal name (UPN) of the user. The UPN is an Internet-style login name for the user based on the Internet standard RFC 822. By convention, this should map to the user's email name. The general format is alias@domain, where domain must be present in the tenant's collection of verified domains. This property is required when a user is created. The verified domains for the tenant can be accessed from the verifiedDomains property of organization. Supports $filter and $orderby. */
+		userPrincipalName?: string
+
+	    /** A string value that can be used to classify user types in your directory, such as "Member" and "Guest". Supports $filter. */
+		userType?: string
+
 	    /** Settings for the primary mailbox of the signed-in user. You can get or update settings for sending automatic replies to incoming messages, locale and time zone. */
-		        mailboxSettings?: MailboxSettings
-	
+		mailboxSettings?: MailboxSettings
+
 	    /** A freeform text entry field for the user to describe themselves. */
-		        aboutMe?: string
-	
+		aboutMe?: string
+
 	    /** The birthday of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        birthday: string
-	
+		birthday?: string
+
 	    /** The hire date of the user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        hireDate: string
-	
+		hireDate?: string
+
 	    /** A list for the user to describe their interests. */
-		        interests?: string[]
-	
+		interests?: string[]
+
 	    /** The URL for the user's personal site. */
-		        mySite?: string
-	
+		mySite?: string
+
 	    /** A list for the user to enumerate their past projects. */
-		        pastProjects?: string[]
-	
+		pastProjects?: string[]
+
 	    /** The preferred name for the user. */
-		        preferredName?: string
-	
+		preferredName?: string
+
 	    /** A list for the user to enumerate their responsibilities. */
-		        responsibilities?: string[]
-	
+		responsibilities?: string[]
+
 	    /** A list for the user to enumerate the schools they have attended. */
-		        schools?: string[]
-	
+		schools?: string[]
+
 	    /** A list for the user to enumerate their skills. */
-		        skills?: string[]
-	
-		        deviceEnrollmentLimit: number
-	
+		skills?: string[]
+
+		deviceEnrollmentLimit?: number
+
 	    /** Devices that are owned by the user. Read-only. Nullable. */
-		        ownedDevices?: DirectoryObject[]
-	
+		ownedDevices?: DirectoryObject[]
+
 	    /** Devices that are registered for the user. Read-only. Nullable. */
-		        registeredDevices?: DirectoryObject[]
-	
-	    /** The user or contact that is this user’s manager. Read-only. (HTTP Methods: GET, PUT, DELETE.) */
-		        manager?: DirectoryObject
-	
+		registeredDevices?: DirectoryObject[]
+
+	    /** The user or contact that is this user's manager. Read-only. (HTTP Methods: GET, PUT, DELETE.) */
+		manager?: DirectoryObject
+
 	    /** The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. */
-		        directReports?: DirectoryObject[]
-	
+		directReports?: DirectoryObject[]
+
 	    /** The groups and directory roles that the user is a member of. Read-only. Nullable. */
-		        memberOf?: DirectoryObject[]
-	
+		memberOf?: DirectoryObject[]
+
 	    /** Directory objects that were created by the user. Read-only. Nullable. */
-		        createdObjects?: DirectoryObject[]
-	
+		createdObjects?: DirectoryObject[]
+
 	    /** Directory objects that are owned by the user. Read-only. Nullable. */
-		        ownedObjects?: DirectoryObject[]
-	
-		        licenseDetails?: LicenseDetails[]
-	
+		ownedObjects?: DirectoryObject[]
+
+		licenseDetails?: LicenseDetails[]
+
 	    /** The collection of open extensions defined for the user. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
-		        outlook?: OutlookUser
-	
+		extensions?: Extension[]
+
+		outlook?: OutlookUser
+
 	    /** The messages in a mailbox or folder. Read-only. Nullable. */
-		        messages?: Message[]
-	
+		messages?: Message[]
+
 	    /** The user's mail folders. Read-only. Nullable. */
-		        mailFolders?: MailFolder[]
-	
+		mailFolders?: MailFolder[]
+
 	    /** The user's primary calendar. Read-only. */
-		        calendar?: Calendar
-	
+		calendar?: Calendar
+
 	    /** The user's calendars. Read-only. Nullable. */
-		        calendars?: Calendar[]
-	
+		calendars?: Calendar[]
+
 	    /** The user's calendar groups. Read-only. Nullable. */
-		        calendarGroups?: CalendarGroup[]
-	
+		calendarGroups?: CalendarGroup[]
+
 	    /** The calendar view for the calendar. Read-only. Nullable. */
-		        calendarView?: Event[]
-	
+		calendarView?: Event[]
+
 	    /** The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable. */
-		        events?: Event[]
-	
-		        people?: Person[]
-	
+		events?: Event[]
+
+		people?: Person[]
+
 	    /** The user's contacts. Read-only. Nullable. */
-		        contacts?: Contact[]
-	
+		contacts?: Contact[]
+
 	    /** The user's contacts folders. Read-only. Nullable. */
-		        contactFolders?: ContactFolder[]
-	
+		contactFolders?: ContactFolder[]
+
 	    /** Relevance classification of the user's messages based on explicit designations which override inferred relevance or importance. */
-		        inferenceClassification?: InferenceClassification
-	
+		inferenceClassification?: InferenceClassification
+
 	    /** The user's profile photo. Read-only. */
-		        photo?: ProfilePhoto
-	
-		        photos?: ProfilePhoto[]
-	
+		photo?: ProfilePhoto
+
+		photos?: ProfilePhoto[]
+
 	    /** The user's OneDrive. Read-only. */
-		        drive?: Drive
-	
+		drive?: Drive
+
 	    /** A collection of drives available for this user. Read-only. */
-		        drives?: Drive[]
-	
-		        planner?: PlannerUser
-	
+		drives?: Drive[]
+
+		planner?: PlannerUser
+
 	    /** Read-only. */
-		        onenote?: Onenote
-	
+		onenote?: Onenote
+
 	    /** The managed devices associated with the user. */
-		        managedDevices?: ManagedDevice[]
-	
+		managedDevices?: ManagedDevice[]
+
 	    /** Zero or more managed app registrations that belong to the user. */
-		        managedAppRegistrations?: ManagedAppRegistration[]
-	
+		managedAppRegistrations?: ManagedAppRegistration[]
+
 	    /** The list of troubleshooting events for this user. */
-		        deviceManagementTroubleshootingEvents?: DeviceManagementTroubleshootingEvent[]
-	
-		        activities?: UserActivity[]
-	
+		deviceManagementTroubleshootingEvents?: DeviceManagementTroubleshootingEvent[]
+
+		activities?: UserActivity[]
+
+		insights?: OfficeGraphInsights
+
+		settings?: UserSettings
+
 }
 
 export interface OutlookUser extends Entity {
 
-		        masterCategories?: OutlookCategory[]
-	
+		masterCategories?: OutlookCategory[]
+
 }
 
 export interface Message extends OutlookItem {
 
 	    /** The date and time the message was received. */
-		        receivedDateTime?: string
-	
+		receivedDateTime?: string
+
 	    /** The date and time the message was sent. */
-		        sentDateTime?: string
-	
+		sentDateTime?: string
+
 	    /** Indicates whether the message has attachments. This property doesn't include inline attachments, so if a message contains only inline attachments, this property is false. To verify the existence of inline attachments, parse the body property to look for a src attribute, such as <IMG src="cid:image001.jpg@01D26CD8.6C05F070">. */
-		        hasAttachments?: boolean
-	
+		hasAttachments?: boolean
+
 	    /** The message ID in the format specified by RFC2822. */
-		        internetMessageId?: string
-	
+		internetMessageId?: string
+
 	    /** The collection of message headers, defined by RFC5322, that provide details of the network path taken by a message from the sender to the recipient. Read-only. */
-		        internetMessageHeaders?: InternetMessageHeader[]
-	
+		internetMessageHeaders?: InternetMessageHeader[]
+
 	    /** The subject of the message. */
-		        subject?: string
-	
+		subject?: string
+
 	    /** The body of the message. It can be in HTML or text format. */
-		        body?: ItemBody
-	
+		body?: ItemBody
+
 	    /** The first 255 characters of the message body. It is in text format. */
-		        bodyPreview?: string
-	
+		bodyPreview?: string
+
 	    /** The importance of the message: Low, Normal, High. */
-		        importance?: Importance
-	
+		importance?: Importance
+
 	    /** The unique identifier for the message's parent mailFolder. */
-		        parentFolderId?: string
-	
+		parentFolderId?: string
+
 	    /** The account that is actually used to generate the message. */
-		        sender?: Recipient
-	
+		sender?: Recipient
+
 	    /** The mailbox owner and sender of the message. */
-		        from?: Recipient
-	
+		from?: Recipient
+
 	    /** The To: recipients for the message. */
-		        toRecipients?: Recipient[]
-	
+		toRecipients?: Recipient[]
+
 	    /** The Cc: recipients for the message. */
-		        ccRecipients?: Recipient[]
-	
+		ccRecipients?: Recipient[]
+
 	    /** The Bcc: recipients for the message. */
-		        bccRecipients?: Recipient[]
-	
+		bccRecipients?: Recipient[]
+
 	    /** The email addresses to use when replying. */
-		        replyTo?: Recipient[]
-	
+		replyTo?: Recipient[]
+
 	    /** The ID of the conversation the email belongs to. */
-		        conversationId?: string
-	
+		conversationId?: string
+
 	    /** The part of the body of the message that is unique to the current message. uniqueBody is not returned by default but can be retrieved for a given message by use of the ?$select=uniqueBody query. It can be in HTML or text format. */
-		        uniqueBody?: ItemBody
-	
+		uniqueBody?: ItemBody
+
 	    /** Indicates whether a read receipt is requested for the message. */
-		        isDeliveryReceiptRequested?: boolean
-	
+		isDeliveryReceiptRequested?: boolean
+
 	    /** Indicates whether a read receipt is requested for the message. */
-		        isReadReceiptRequested?: boolean
-	
+		isReadReceiptRequested?: boolean
+
 	    /** Indicates whether the message has been read. */
-		        isRead?: boolean
-	
+		isRead?: boolean
+
 	    /** Indicates whether the message is a draft. A message is a draft if it hasn't been sent yet. */
-		        isDraft?: boolean
-	
+		isDraft?: boolean
+
 	    /** The URL to open the message in Outlook Web App.You can append an ispopout argument to the end of the URL to change how the message is displayed. If ispopout is not present or if it is set to 1, then the message is shown in a popout window. If ispopout is set to 0, then the browser will show the message in the Outlook Web App review pane.The message will open in the browser if you are logged in to your mailbox via Outlook Web App. You will be prompted to login if you are not already logged in with the browser.This URL can be accessed from within an iFrame. */
-		        webLink?: string
-	
+		webLink?: string
+
 	    /** The classification of the message for the user, based on inferred relevance or importance, or on an explicit override. Possible values are: focused or other. */
-		        inferenceClassification?: InferenceClassificationType
-	
+		inferenceClassification?: InferenceClassificationType
+
 	    /** The flag value that indicates the status, start date, due date, or completion date for the message. */
-		        flag?: FollowupFlag
-	
+		flag?: FollowupFlag
+
 	    /** The fileAttachment and itemAttachment attachments for the message. */
-		        attachments?: Attachment[]
-	
+		attachments?: Attachment[]
+
 	    /** The collection of open extensions defined for the message. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 	    /** The collection of single-value extended properties defined for the message. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the message. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface MailFolder extends Entity {
 
 	    /** The mailFolder's display name. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The unique identifier for the mailFolder's parent mailFolder. */
-		        parentFolderId?: string
-	
+		parentFolderId?: string
+
 	    /** The number of immediate child mailFolders in the current mailFolder. */
-		        childFolderCount?: number
-	
+		childFolderCount?: number
+
 	    /** The number of items in the mailFolder marked as unread. */
-		        unreadItemCount?: number
-	
+		unreadItemCount?: number
+
 	    /** The number of items in the mailFolder. */
-		        totalItemCount?: number
-	
+		totalItemCount?: number
+
 	    /** The collection of messages in the mailFolder. */
-		        messages?: Message[]
-	
+		messages?: Message[]
+
 	    /** The collection of rules that apply to the user's Inbox folder. */
-		        messageRules?: MessageRule[]
-	
+		messageRules?: MessageRule[]
+
 	    /** The collection of child folders in the mailFolder. */
-		        childFolders?: MailFolder[]
-	
+		childFolders?: MailFolder[]
+
 	    /** The collection of single-value extended properties defined for the mailFolder. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the mailFolder. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface CalendarGroup extends Entity {
 
 	    /** The group name. */
-		        name?: string
-	
+		name?: string
+
 	    /** The class identifier. Read-only. */
-		        classId?: string
-	
+		classId?: string
+
 	    /** Identifies the version of the calendar group. Every time the calendar group is changed, ChangeKey changes as well. This allows Exchange to apply changes to the correct version of the object. Read-only. */
-		        changeKey?: string
-	
+		changeKey?: string
+
 	    /** The calendars in the calendar group. Navigation property. Read-only. Nullable. */
-		        calendars?: Calendar[]
-	
+		calendars?: Calendar[]
+
 }
 
 export interface Person extends Entity {
 
 	    /** The person's display name. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The person's given name. */
-		        givenName?: string
-	
+		givenName?: string
+
 	    /** The person's surname. */
-		        surname?: string
-	
+		surname?: string
+
 	    /** The person's birthday. */
-		        birthday?: string
-	
+		birthday?: string
+
 	    /** Free-form notes that the user has taken about this person. */
-		        personNotes?: string
-	
+		personNotes?: string
+
 	    /** true if the user has flagged this person as a favorite. */
-		        isFavorite?: boolean
-	
+		isFavorite?: boolean
+
 	    /** The person's email addresses. */
-		        scoredEmailAddresses?: ScoredEmailAddress[]
-	
+		scoredEmailAddresses?: ScoredEmailAddress[]
+
 	    /** The person's phone numbers. */
-		        phones?: Phone[]
-	
+		phones?: Phone[]
+
 	    /** The person's addresses. */
-		        postalAddresses?: Location[]
-	
+		postalAddresses?: Location[]
+
 	    /** The person's websites. */
-		        websites?: Website[]
-	
+		websites?: Website[]
+
 	    /** The person's job title. */
-		        jobTitle?: string
-	
+		jobTitle?: string
+
 	    /** The name of the person's company. */
-		        companyName?: string
-	
+		companyName?: string
+
 	    /** The phonetic Japanese name of the person's company. */
-		        yomiCompany?: string
-	
+		yomiCompany?: string
+
 	    /** The person's department. */
-		        department?: string
-	
+		department?: string
+
 	    /** The location of the person's office. */
-		        officeLocation?: string
-	
+		officeLocation?: string
+
 	    /** The person's profession. */
-		        profession?: string
-	
+		profession?: string
+
 	    /** The type of person. */
-		        personType?: PersonType
-	
+		personType?: PersonType
+
 	    /** The user principal name (UPN) of the person. The UPN is an Internet-style login name for the person based on the Internet standard RFC 822. By convention, this should map to the person's email name. The general format is alias@domain. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 	    /** The instant message voice over IP (VOIP) session initiation protocol (SIP) address for the user. Read-only. */
-		        imAddress?: string
-	
+		imAddress?: string
+
 }
 
 export interface Contact extends OutlookItem {
 
 	    /** The ID of the contact's parent folder. */
-		        parentFolderId?: string
-	
+		parentFolderId?: string
+
 	    /** The contact's birthday. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        birthday?: string
-	
+		birthday?: string
+
 	    /** The name the contact is filed under. */
-		        fileAs?: string
-	
+		fileAs?: string
+
 	    /** The contact's display name. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The contact's given name. */
-		        givenName?: string
-	
+		givenName?: string
+
 	    /** The contact's initials. */
-		        initials?: string
-	
+		initials?: string
+
 	    /** The contact's middle name. */
-		        middleName?: string
-	
+		middleName?: string
+
 	    /** The contact's nickname. */
-		        nickName?: string
-	
+		nickName?: string
+
 	    /** The contact's surname. */
-		        surname?: string
-	
+		surname?: string
+
 	    /** The contact's title. */
-		        title?: string
-	
+		title?: string
+
 	    /** The phonetic Japanese given name (first name) of the contact. */
-		        yomiGivenName?: string
-	
+		yomiGivenName?: string
+
 	    /** The phonetic Japanese surname (last name)  of the contact. */
-		        yomiSurname?: string
-	
+		yomiSurname?: string
+
 	    /** The phonetic Japanese company name of the contact. */
-		        yomiCompanyName?: string
-	
+		yomiCompanyName?: string
+
 	    /** The contact's generation. */
-		        generation?: string
-	
+		generation?: string
+
 	    /** The contact's email addresses. */
-		        emailAddresses?: EmailAddress[]
-	
+		emailAddresses?: EmailAddress[]
+
 	    /** The contact's instant messaging (IM) addresses. */
-		        imAddresses?: string[]
-	
-	    /** The contact’s job title. */
-		        jobTitle?: string
-	
+		imAddresses?: string[]
+
+	    /** The contact's job title. */
+		jobTitle?: string
+
 	    /** The name of the contact's company. */
-		        companyName?: string
-	
+		companyName?: string
+
 	    /** The contact's department. */
-		        department?: string
-	
+		department?: string
+
 	    /** The location of the contact's office. */
-		        officeLocation?: string
-	
+		officeLocation?: string
+
 	    /** The contact's profession. */
-		        profession?: string
-	
+		profession?: string
+
 	    /** The business home page of the contact. */
-		        businessHomePage?: string
-	
+		businessHomePage?: string
+
 	    /** The name of the contact's assistant. */
-		        assistantName?: string
-	
+		assistantName?: string
+
 	    /** The name of the contact's manager. */
-		        manager?: string
-	
+		manager?: string
+
 	    /** The contact's home phone numbers. */
-		        homePhones?: string[]
-	
+		homePhones?: string[]
+
 	    /** The contact's mobile phone number. */
-		        mobilePhone?: string
-	
+		mobilePhone?: string
+
 	    /** The contact's business phone numbers. */
-		        businessPhones?: string[]
-	
+		businessPhones?: string[]
+
 	    /** The contact's home address. */
-		        homeAddress?: PhysicalAddress
-	
+		homeAddress?: PhysicalAddress
+
 	    /** The contact's business address. */
-		        businessAddress?: PhysicalAddress
-	
+		businessAddress?: PhysicalAddress
+
 	    /** Other addresses for the contact. */
-		        otherAddress?: PhysicalAddress
-	
+		otherAddress?: PhysicalAddress
+
 	    /** The name of the contact's spouse/partner. */
-		        spouseName?: string
-	
+		spouseName?: string
+
 	    /** The user's notes about the contact. */
-		        personalNotes?: string
-	
+		personalNotes?: string
+
 	    /** The names of the contact's children. */
-		        children?: string[]
-	
+		children?: string[]
+
 	    /** The collection of open extensions defined for the contact. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 	    /** The collection of single-value extended properties defined for the contact. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the contact. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 	    /** Optional contact picture. You can get or set a photo for a contact. */
-		        photo?: ProfilePhoto
-	
+		photo?: ProfilePhoto
+
 }
 
 export interface ContactFolder extends Entity {
 
 	    /** The ID of the folder's parent folder. */
-		        parentFolderId?: string
-	
+		parentFolderId?: string
+
 	    /** The folder's display name. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The contacts in the folder. Navigation property. Read-only. Nullable. */
-		        contacts?: Contact[]
-	
+		contacts?: Contact[]
+
 	    /** The collection of child folders in the folder. Navigation property. Read-only. Nullable. */
-		        childFolders?: ContactFolder[]
-	
+		childFolders?: ContactFolder[]
+
 	    /** The collection of single-value extended properties defined for the contactFolder. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the contactFolder. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface InferenceClassification extends Entity {
 
 	    /** A set of overrides for a user to always classify messages from specific senders in certain ways: focused, or other. Read-only. Nullable. */
-		        overrides?: InferenceClassificationOverride[]
-	
+		overrides?: InferenceClassificationOverride[]
+
 }
 
 export interface PlannerUser extends Entity {
 
 	    /** Read-only. Nullable. Returns the plannerPlans shared with the user. */
-		        tasks?: PlannerTask[]
-	
+		tasks?: PlannerTask[]
+
 	    /** Read-only. Nullable. Returns the plannerTasks assigned to the user. */
-		        plans?: PlannerPlan[]
-	
+		plans?: PlannerPlan[]
+
 }
 
 export interface ManagedDevice extends Entity {
 
 	    /** Unique Identifier for the user associated with the device */
-		        userId?: string
-	
+		userId?: string
+
 	    /** Name of the device */
-		        deviceName?: string
-	
+		deviceName?: string
+
 	    /** Ownership of the device. Can be 'company' or 'personal'. Possible values are: unknown, company, personal. */
-		        managedDeviceOwnerType: ManagedDeviceOwnerType
-	
+		managedDeviceOwnerType?: ManagedDeviceOwnerType
+
 	    /** List of ComplexType deviceActionResult objects. */
-		        deviceActionResults?: DeviceActionResult[]
-	
+		deviceActionResults?: DeviceActionResult[]
+
 	    /** Enrollment time of the device. */
-		        enrolledDateTime: string
-	
+		enrolledDateTime?: string
+
 	    /** The date and time that the device last completed a successful sync with Intune. */
-		        lastSyncDateTime: string
-	
+		lastSyncDateTime?: string
+
 	    /** Operating system of the device. Windows, iOS, etc. */
-		        operatingSystem?: string
-	
+		operatingSystem?: string
+
 	    /** Compliance state of the device. Possible values are: unknown, compliant, noncompliant, conflict, error, inGracePeriod, configManager. */
-		        complianceState: ComplianceState
-	
+		complianceState?: ComplianceState
+
 	    /** whether the device is jail broken or rooted. */
-		        jailBroken?: string
-	
+		jailBroken?: string
+
 	    /** Management channel of the device. Intune, EAS, etc. Possible values are: eas, mdm, easMdm, intuneClient, easIntuneClient, configurationManagerClient, configurationManagerClientMdm, configurationManagerClientMdmEas, unknown, jamf, googleCloudDevicePolicyController. */
-		        managementAgent: ManagementAgentType
-	
+		managementAgent?: ManagementAgentType
+
 	    /** Operating system version of the device. */
-		        osVersion?: string
-	
+		osVersion?: string
+
 	    /** Whether the device is Exchange ActiveSync activated. */
-		        easActivated: boolean
-	
+		easActivated?: boolean
+
 	    /** Exchange ActiveSync Id of the device. */
-		        easDeviceId?: string
-	
+		easDeviceId?: string
+
 	    /** Exchange ActivationSync activation time of the device. */
-		        easActivationDateTime: string
-	
+		easActivationDateTime?: string
+
 	    /** Whether the device is Azure Active Directory registered. */
-		        azureADRegistered?: boolean
-	
+		azureADRegistered?: boolean
+
 	    /** Enrollment type of the device. Possible values are: unknown, userEnrollment, deviceEnrollmentManager, appleBulkWithUser, appleBulkWithoutUser, windowsAzureADJoin, windowsBulkUserless, windowsAutoEnrollment, windowsBulkAzureDomainJoin, windowsCoManagement. */
-		        deviceEnrollmentType: DeviceEnrollmentType
-	
+		deviceEnrollmentType?: DeviceEnrollmentType
+
 	    /** Code that allows the Activation Lock on a device to be bypassed. */
-		        activationLockBypassCode?: string
-	
+		activationLockBypassCode?: string
+
 	    /** Email(s) for the user associated with the device */
-		        emailAddress?: string
-	
+		emailAddress?: string
+
 	    /** The unique identifier for the Azure Active Directory device. Read only. */
-		        azureADDeviceId?: string
-	
+		azureADDeviceId?: string
+
 	    /** Device registration state. Possible values are: notRegistered, registered, revoked, keyConflict, approvalPending, certificateReset, notRegisteredPendingEnrollment, unknown. */
-		        deviceRegistrationState: DeviceRegistrationState
-	
+		deviceRegistrationState?: DeviceRegistrationState
+
 	    /** Device category display name */
-		        deviceCategoryDisplayName?: string
-	
+		deviceCategoryDisplayName?: string
+
 	    /** Device supervised status */
-		        isSupervised: boolean
-	
+		isSupervised?: boolean
+
 	    /** Last time the device contacted Exchange. */
-		        exchangeLastSuccessfulSyncDateTime: string
-	
+		exchangeLastSuccessfulSyncDateTime?: string
+
 	    /** The Access State of the device in Exchange. Possible values are: none, unknown, allowed, blocked, quarantined. */
-		        exchangeAccessState: DeviceManagementExchangeAccessState
-	
+		exchangeAccessState?: DeviceManagementExchangeAccessState
+
 	    /** The reason for the device's access state in Exchange. Possible values are: none, unknown, exchangeGlobalRule, exchangeIndividualRule, exchangeDeviceRule, exchangeUpgrade, exchangeMailboxPolicy, other, compliant, notCompliant, notEnrolled, unknownLocation, mfaRequired, azureADBlockDueToAccessPolicy, compromisedPassword, deviceNotKnownWithManagedApp. */
-		        exchangeAccessStateReason: DeviceManagementExchangeAccessStateReason
-	
+		exchangeAccessStateReason?: DeviceManagementExchangeAccessStateReason
+
 	    /** Url that allows a Remote Assistance session to be established with the device. */
-		        remoteAssistanceSessionUrl?: string
-	
+		remoteAssistanceSessionUrl?: string
+
 	    /** An error string that identifies issues when creating Remote Assistance session objects. */
-		        remoteAssistanceSessionErrorDetails?: string
-	
+		remoteAssistanceSessionErrorDetails?: string
+
 	    /** Device encryption status */
-		        isEncrypted: boolean
-	
+		isEncrypted?: boolean
+
 	    /** Device user principal name */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 	    /** Model of the device */
-		        model?: string
-	
+		model?: string
+
 	    /** Manufacturer of the device */
-		        manufacturer?: string
-	
+		manufacturer?: string
+
 	    /** IMEI */
-		        imei?: string
-	
+		imei?: string
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 	    /** SerialNumber */
-		        serialNumber?: string
-	
+		serialNumber?: string
+
 	    /** Phone number of the device */
-		        phoneNumber?: string
-	
+		phoneNumber?: string
+
 	    /** Android security patch level */
-		        androidSecurityPatchLevel?: string
-	
+		androidSecurityPatchLevel?: string
+
 	    /** User display name */
-		        userDisplayName?: string
-	
+		userDisplayName?: string
+
 	    /** ConfigrMgr client enabled features */
-		        configurationManagerClientEnabledFeatures?: ConfigurationManagerClientEnabledFeatures
-	
+		configurationManagerClientEnabledFeatures?: ConfigurationManagerClientEnabledFeatures
+
 	    /** Wi-Fi MAC */
-		        wiFiMacAddress?: string
-	
+		wiFiMacAddress?: string
+
 	    /** The device health attestation state. */
-		        deviceHealthAttestationState?: DeviceHealthAttestationState
-	
+		deviceHealthAttestationState?: DeviceHealthAttestationState
+
 	    /** Subscriber Carrier */
-		        subscriberCarrier?: string
-	
+		subscriberCarrier?: string
+
 	    /** MEID */
-		        meid?: string
-	
+		meid?: string
+
 	    /** Total Storage in Bytes */
-		        totalStorageSpaceInBytes: number
-	
+		totalStorageSpaceInBytes?: number
+
 	    /** Free Storage in Bytes */
-		        freeStorageSpaceInBytes: number
-	
+		freeStorageSpaceInBytes?: number
+
 	    /** Automatically generated name to identify a device. Can be overwritten to a user friendly name. */
-		        managedDeviceName?: string
-	
+		managedDeviceName?: string
+
 	    /** Indicates the threat state of a device when a Mobile Threat Defense partner is in use by the account and device. Read Only. Possible values are: unknown, activated, deactivated, secured, lowSeverity, mediumSeverity, highSeverity, unresponsive. */
-		        partnerReportedThreatState: ManagedDevicePartnerReportedHealthState
-	
-		        deviceConfigurationStates?: DeviceConfigurationState[]
-	
+		partnerReportedThreatState?: ManagedDevicePartnerReportedHealthState
+
+		deviceConfigurationStates?: DeviceConfigurationState[]
+
 	    /** Device category */
-		        deviceCategory?: DeviceCategory
-	
-		        deviceCompliancePolicyStates?: DeviceCompliancePolicyState[]
-	
+		deviceCategory?: DeviceCategory
+
+		deviceCompliancePolicyStates?: DeviceCompliancePolicyState[]
+
 }
 
 export interface ManagedAppRegistration extends Entity {
 
 	    /** Date and time of creation */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Date and time of last the app synced with management service. */
-		        lastSyncDateTime: string
-	
+		lastSyncDateTime?: string
+
 	    /** App version */
-		        applicationVersion?: string
-	
+		applicationVersion?: string
+
 	    /** App management SDK version */
-		        managementSdkVersion?: string
-	
+		managementSdkVersion?: string
+
 	    /** Operating System version */
-		        platformVersion?: string
-	
+		platformVersion?: string
+
 	    /** Host device type */
-		        deviceType?: string
-	
+		deviceType?: string
+
 	    /** App management SDK generated tag, which helps relate apps hosted on the same device. Not guaranteed to relate apps in all conditions. */
-		        deviceTag?: string
-	
+		deviceTag?: string
+
 	    /** Host device name */
-		        deviceName?: string
-	
+		deviceName?: string
+
 	    /** Zero or more reasons an app registration is flagged. E.g. app running on rooted device */
-		        flaggedReasons: ManagedAppFlaggedReason[]
-	
+		flaggedReasons?: ManagedAppFlaggedReason[]
+
 	    /** The user Id to who this app registration belongs. */
-		        userId?: string
-	
+		userId?: string
+
 	    /** The app package Identifier */
-		        appIdentifier?: MobileAppIdentifier
-	
+		appIdentifier?: MobileAppIdentifier
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 	    /** Zero or more policys already applied on the registered app when it last synchronized with managment service. */
-		        appliedPolicies?: ManagedAppPolicy[]
-	
+		appliedPolicies?: ManagedAppPolicy[]
+
 	    /** Zero or more policies admin intended for the app as of now. */
-		        intendedPolicies?: ManagedAppPolicy[]
-	
+		intendedPolicies?: ManagedAppPolicy[]
+
 	    /** Zero or more long running operations triggered on the app registration. */
-		        operations?: ManagedAppOperation[]
-	
+		operations?: ManagedAppOperation[]
+
 }
 
 export interface DeviceManagementTroubleshootingEvent extends Entity {
 
 	    /** Time when the event occurred . */
-		        eventDateTime: string
-	
+		eventDateTime?: string
+
 	    /** Id used for tracing the failure in the service. */
-		        correlationId?: string
-	
+		correlationId?: string
+
 }
 
 export interface UserActivity extends Entity {
 
-		        visualElements: VisualInfo
-	
-		        activitySourceHost: string
-	
-		        activationUrl: string
-	
-		        appActivityId: string
-	
-		        appDisplayName?: string
-	
-		        contentUrl?: string
-	
-		        createdDateTime?: string
-	
-		        expirationDateTime?: string
-	
-		        fallbackUrl?: string
-	
-		        lastModifiedDateTime?: string
-	
-		        userTimezone?: string
-	
-		        contentInfo?: any
-	
-		        status?: Status
-	
-		        historyItems?: ActivityHistoryItem[]
-	
+		visualElements?: VisualInfo
+
+		activitySourceHost?: string
+
+		activationUrl?: string
+
+		appActivityId?: string
+
+		appDisplayName?: string
+
+		contentUrl?: string
+
+		createdDateTime?: string
+
+		expirationDateTime?: string
+
+		fallbackUrl?: string
+
+		lastModifiedDateTime?: string
+
+		userTimezone?: string
+
+		contentInfo?: any
+
+		status?: Status
+
+		historyItems?: ActivityHistoryItem[]
+
+}
+
+export interface OfficeGraphInsights extends Entity {
+
+		trending?: Trending[]
+
+		shared?: SharedInsight[]
+
+		used?: UsedInsight[]
+
+}
+
+export interface UserSettings extends Entity {
+
+		contributionToContentDiscoveryDisabled?: boolean
+
+		contributionToContentDiscoveryAsOrganizationDisabled?: boolean
+
 }
 
 export interface GroupSettingTemplate extends DirectoryObject {
 
 	    /** Display name of the template. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Description of the template. */
-		        description?: string
-	
+		description?: string
+
 	    /** Collection of settingTemplateValues that list the set of available settings, defaults and types that make up this template. */
-		        values: SettingTemplateValue[]
-	
+		values?: SettingTemplateValue[]
+
 }
 
 export interface SchemaExtension extends Entity {
 
 	    /** Description for the schema extension. */
-		        description?: string
-	
+		description?: string
+
 	    /** Set of Microsoft Graph types (that can support extensions) that the schema extension can be applied to. Select from contact, device, event, group, message, organization, post, or user. */
-		        targetTypes: string[]
-	
+		targetTypes?: string[]
+
 	    /** The collection of property names and types that make up the schema extension definition. */
-		        properties: ExtensionSchemaProperty[]
-	
+		properties?: ExtensionSchemaProperty[]
+
 	    /** The lifecycle state of the schema extension. Possible states are InDevelopment, Available, and Deprecated. Automatically set to InDevelopment on creation. Schema extensions provides more information on the possible state transitions and behaviors. */
-		        status: string
-	
+		status?: string
+
 	    /** The appId of the application that is the owner of the schema extension. This property can be supplied on creation, to set the owner.  If not supplied, then the calling application's appId will be set as the owner. In either case, the signed-in user must be the owner of the application. Once set, this property is read-only and cannot be changed. */
-		        owner: string
-	
+		owner?: string
+
 }
 
 export interface Attachment extends Entity {
 
 	    /** The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        lastModifiedDateTime?: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The attachment's file name. */
-		        name?: string
-	
+		name?: string
+
 	    /** The MIME type. */
-		        contentType?: string
-	
+		contentType?: string
+
 	    /** The length of the attachment in bytes. */
-		        size: number
-	
+		size?: number
+
 	    /** true if the attachment is an inline attachment; otherwise, false. */
-		        isInline: boolean
-	
+		isInline?: boolean
+
 }
 
 export interface OutlookCategory extends Entity {
 
 	    /** A unique name that identifies a category in the user's mailbox. After a category is created, the name cannot be changed. Read-only. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** A pre-set color constant that characterizes a category, and that is mapped to one of 25 predefined colors. See the note below. */
-		        color?: CategoryColor
-	
+		color?: CategoryColor
+
 }
 
 export interface MessageRule extends Entity {
 
 	    /** The display name of the rule. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Indicates the order in which the rule is executed, among other rules. */
-		        sequence?: number
-	
+		sequence?: number
+
 	    /** Conditions that when fulfilled, will trigger the corresponding actions for that rule. */
-		        conditions?: MessageRulePredicates
-	
+		conditions?: MessageRulePredicates
+
 	    /** Actions to be taken on a message when the corresponding conditions are fulfilled. */
-		        actions?: MessageRuleActions
-	
+		actions?: MessageRuleActions
+
 	    /** Exception conditions for the rule. */
-		        exceptions?: MessageRulePredicates
-	
+		exceptions?: MessageRulePredicates
+
 	    /** Indicates whether the rule is enabled to be applied to messages. */
-		        isEnabled?: boolean
-	
+		isEnabled?: boolean
+
 	    /** Indicates whether the rule is in an error condition. Read-only. */
-		        hasError?: boolean
-	
+		hasError?: boolean
+
 	    /** Indicates if the rule is read-only and cannot be modified or deleted by the rules REST API. */
-		        isReadOnly?: boolean
-	
+		isReadOnly?: boolean
+
 }
 
 export interface SingleValueLegacyExtendedProperty extends Entity {
 
 	    /** A property value. */
-		        value?: string
-	
+		value?: string
+
 }
 
 export interface MultiValueLegacyExtendedProperty extends Entity {
 
-		        value?: string[]
-	
+		value?: string[]
+
 }
 
 export interface FileAttachment extends Attachment {
 
 	    /** The ID of the attachment in the Exchange store. */
-		        contentId?: string
-	
+		contentId?: string
+
 	    /** The Uniform Resource Identifier (URI) that corresponds to the location of the content of the attachment. */
-		        contentLocation?: string
-	
+		contentLocation?: string
+
 	    /** The base64-encoded contents of the file. */
-		        contentBytes?: number
-	
+		contentBytes?: number
+
 }
 
 export interface ItemAttachment extends Attachment {
 
 	    /** The attached message or event. Navigation property. */
-		        item?: OutlookItem
-	
+		item?: OutlookItem
+
 }
 
 export interface EventMessage extends Message {
 
 	    /** The type of event message: none, meetingRequest, meetingCancelled, meetingAccepted, meetingTenativelyAccepted, meetingDeclined. */
-		        meetingMessageType?: MeetingMessageType
-	
+		meetingMessageType?: MeetingMessageType
+
 	    /** The event associated with the event message. The assumption for attendees or room resources is that the Calendar Attendant is set to automatically update the calendar with an event when meeting request event messages arrive. Navigation property.  Read-only. */
-		        event?: Event
-	
+		event?: Event
+
 }
 
 export interface ReferenceAttachment extends Attachment {
@@ -1944,358 +1997,358 @@ export interface ReferenceAttachment extends Attachment {
 
 export interface OpenTypeExtension extends Extension {
 
-		        extensionName: string
-	
+		extensionName?: string
+
 }
 
 export interface Post extends OutlookItem {
 
 	    /** The contents of the post. This is a default property. This property can be null. */
-		        body?: ItemBody
-	
+		body?: ItemBody
+
 	    /** Specifies when the post was received. The DateTimeOffset type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        receivedDateTime: string
-	
+		receivedDateTime?: string
+
 	    /** Indicates whether the post has at least one attachment. This is a default property. */
-		        hasAttachments: boolean
-	
+		hasAttachments?: boolean
+
 	    /** Used in delegate access scenarios. Indicates who posted the message on behalf of another user. This is a default property. */
-		        from: Recipient
-	
+		from?: Recipient
+
 	    /** Contains the address of the sender. The value of Sender is assumed to be the address of the authenticated user in the case when Sender is not specified. This is a default property. */
-		        sender?: Recipient
-	
+		sender?: Recipient
+
 	    /** Unique ID of the conversation thread. Read-only. */
-		        conversationThreadId?: string
-	
+		conversationThreadId?: string
+
 	    /** Conversation participants that were added to the thread as part of this post. */
-		        newParticipants: Recipient[]
-	
+		newParticipants?: Recipient[]
+
 	    /** Unique ID of the conversation. Read-only. */
-		        conversationId?: string
-	
+		conversationId?: string
+
 	    /** The collection of open extensions defined for the post. Read-only. Nullable. */
-		        extensions?: Extension[]
-	
+		extensions?: Extension[]
+
 	    /** Read-only. */
-		        inReplyTo?: Post
-	
+		inReplyTo?: Post
+
 	    /** Read-only. Nullable. */
-		        attachments?: Attachment[]
-	
+		attachments?: Attachment[]
+
 	    /** The collection of single-value extended properties defined for the post. Read-only. Nullable. */
-		        singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
-	
+		singleValueExtendedProperties?: SingleValueLegacyExtendedProperty[]
+
 	    /** The collection of multi-value extended properties defined for the post. Read-only. Nullable. */
-		        multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
-	
+		multiValueExtendedProperties?: MultiValueLegacyExtendedProperty[]
+
 }
 
 export interface InferenceClassificationOverride extends Entity {
 
 	    /** Specifies how incoming messages from a specific sender should always be classified as. Possible values are: focused, other. */
-		        classifyAs?: InferenceClassificationType
-	
+		classifyAs?: InferenceClassificationType
+
 	    /** The email address information of the sender for whom the override is created. */
-		        senderEmailAddress?: EmailAddress
-	
+		senderEmailAddress?: EmailAddress
+
 }
 
 export interface BaseItemVersion extends Entity {
 
 	    /** Identity of the user which last modified the version. Read-only. */
-		        lastModifiedBy?: IdentitySet
-	
+		lastModifiedBy?: IdentitySet
+
 	    /** Date and time the version was last modified. Read-only. */
-		        lastModifiedDateTime?: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Indicates the publication status of this particular version. Read-only. */
-		        publication?: PublicationFacet
-	
+		publication?: PublicationFacet
+
 }
 
 export interface ColumnDefinition extends Entity {
 
 	    /** This column stores boolean values. */
-		        boolean?: BooleanColumn
-	
+		boolean?: BooleanColumn
+
 	    /** This column's data is calculated based on other columns. */
-		        calculated?: CalculatedColumn
-	
+		calculated?: CalculatedColumn
+
 	    /** This column stores data from a list of choices. */
-		        choice?: ChoiceColumn
-	
+		choice?: ChoiceColumn
+
 	    /** For site columns, the name of the group this column belongs to. Helps organize related columns. */
-		        columnGroup?: string
-	
+		columnGroup?: string
+
 	    /** This column stores currency values. */
-		        currency?: CurrencyColumn
-	
+		currency?: CurrencyColumn
+
 	    /** This column stores DateTime values. */
-		        dateTime?: DateTimeColumn
-	
+		dateTime?: DateTimeColumn
+
 	    /** The default value for this column. */
-		        defaultValue?: DefaultColumnValue
-	
+		defaultValue?: DefaultColumnValue
+
 	    /** The user-facing description of the column. */
-		        description?: string
-	
+		description?: string
+
 	    /** The user-facing name of the column. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** If true, no two list items may have the same value for this column. */
-		        enforceUniqueValues?: boolean
-	
+		enforceUniqueValues?: boolean
+
 	    /** Specifies whether the column is displayed in the user interface. */
-		        hidden?: boolean
-	
+		hidden?: boolean
+
 	    /** Specifies whether the column values can used for sorting and searching. */
-		        indexed?: boolean
-	
+		indexed?: boolean
+
 	    /** This column's data is looked up from another source in the site. */
-		        lookup?: LookupColumn
-	
+		lookup?: LookupColumn
+
 	    /** The API-facing name of the column as it appears in the [fields][] on a [listItem][]. For the user-facing name, see displayName. */
-		        name?: string
-	
+		name?: string
+
 	    /** This column stores number values. */
-		        number?: NumberColumn
-	
+		number?: NumberColumn
+
 	    /** This column stores Person or Group values. */
-		        personOrGroup?: PersonOrGroupColumn
-	
+		personOrGroup?: PersonOrGroupColumn
+
 	    /** Specifies whether the column values can be modified. */
-		        readOnly?: boolean
-	
+		readOnly?: boolean
+
 	    /** Specifies whether the column value is not optional. */
-		        required?: boolean
-	
+		required?: boolean
+
 	    /** This column stores text values. */
-		        text?: TextColumn
-	
+		text?: TextColumn
+
 }
 
 export interface ColumnLink extends Entity {
 
 	    /** The name of the column  in this content type. */
-		        name?: string
-	
+		name?: string
+
 }
 
 export interface ContentType extends Entity {
 
 	    /** The descriptive text for the item. */
-		        description?: string
-	
+		description?: string
+
 	    /** The name of the group this content type belongs to. Helps organize related content types. */
-		        group?: string
-	
+		group?: string
+
 	    /** Indicates whether the content type is hidden in the list's 'New' menu. */
-		        hidden?: boolean
-	
+		hidden?: boolean
+
 	    /** If this content type is inherited from another scope (like a site), provides a reference to the item where the content type is defined. */
-		        inheritedFrom?: ItemReference
-	
+		inheritedFrom?: ItemReference
+
 	    /** The name of the content type. */
-		        name?: string
-	
+		name?: string
+
 	    /** Specifies the order in which the content type appears in the selection UI. */
-		        order?: ContentTypeOrder
-	
+		order?: ContentTypeOrder
+
 	    /** The unique identifier of the content type. */
-		        parentId?: string
-	
+		parentId?: string
+
 	    /** If true, the content type cannot be modified unless this value is first set to false. */
-		        readOnly?: boolean
-	
+		readOnly?: boolean
+
 	    /** If true, the content type cannot be modified by users or through push-down operations. Only site collection administrators can seal or unseal content types. */
-		        sealed?: boolean
-	
+		sealed?: boolean
+
 	    /** The collection of columns that are required by this content type */
-		        columnLinks?: ColumnLink[]
-	
+		columnLinks?: ColumnLink[]
+
 }
 
 export interface DriveItem extends BaseItem {
 
 	    /** Audio metadata, if the item is an audio file. Read-only. */
-		        audio?: Audio
-	
-		        content?: any
-	
+		audio?: Audio
+
+		content?: any
+
 	    /** An eTag for the content of the item. This eTag is not changed if only the metadata is changed. Note This property is not returned if the item is a folder. Read-only. */
-		        cTag?: string
-	
+		cTag?: string
+
 	    /** Information about the deleted state of the item. Read-only. */
-		        deleted?: Deleted
-	
+		deleted?: Deleted
+
 	    /** File metadata, if the item is a file. Read-only. */
-		        file?: File
-	
+		file?: File
+
 	    /** File system information on client. Read-write. */
-		        fileSystemInfo?: FileSystemInfo
-	
+		fileSystemInfo?: FileSystemInfo
+
 	    /** Folder metadata, if the item is a folder. Read-only. */
-		        folder?: Folder
-	
+		folder?: Folder
+
 	    /** Image metadata, if the item is an image. Read-only. */
-		        image?: Image
-	
+		image?: Image
+
 	    /** Location metadata, if the item has location data. Read-only. */
-		        location?: GeoCoordinates
-	
+		location?: GeoCoordinates
+
 	    /** If present, indicates that this item is a package instead of a folder or file. Packages are treated like files in some contexts and folders in others. Read-only. */
-		        package?: Package
-	
+		package?: Package
+
 	    /** Photo metadata, if the item is a photo. Read-only. */
-		        photo?: Photo
-	
-		        publication?: PublicationFacet
-	
+		photo?: Photo
+
+		publication?: PublicationFacet
+
 	    /** Remote item data, if the item is shared from a drive other than the one being accessed. Read-only. */
-		        remoteItem?: RemoteItem
-	
+		remoteItem?: RemoteItem
+
 	    /** If this property is non-null, it indicates that the driveItem is the top-most driveItem in the drive. */
-		        root?: Root
-	
+		root?: Root
+
 	    /** Search metadata, if the item is from a search result. Read-only. */
-		        searchResult?: SearchResult
-	
+		searchResult?: SearchResult
+
 	    /** Indicates that the item has been shared with others and provides information about the shared state of the item. Read-only. */
-		        shared?: Shared
-	
+		shared?: Shared
+
 	    /** Returns identifiers useful for SharePoint REST compatibility. Read-only. */
-		        sharepointIds?: SharepointIds
-	
+		sharepointIds?: SharepointIds
+
 	    /** Size of the item in bytes. Read-only. */
-		        size?: number
-	
+		size?: number
+
 	    /** If the current item is also available as a special folder, this facet is returned. Read-only. */
-		        specialFolder?: SpecialFolder
-	
+		specialFolder?: SpecialFolder
+
 	    /** Video metadata, if the item is a video. Read-only. */
-		        video?: Video
-	
+		video?: Video
+
 	    /** WebDAV compatible URL for the item. */
-		        webDavUrl?: string
-	
+		webDavUrl?: string
+
 	    /** Collection containing Item objects for the immediate children of Item. Only items representing folders have children. Read-only. Nullable. */
-		        children?: DriveItem[]
-	
-		        listItem?: ListItem
-	
+		children?: DriveItem[]
+
+		listItem?: ListItem
+
 	    /** The set of permissions for the item. Read-only. Nullable. */
-		        permissions?: Permission[]
-	
+		permissions?: Permission[]
+
 	    /** Collection containing [ThumbnailSet][] objects associated with the item. For more info, see [getting thumbnails][]. Read-only. Nullable. */
-		        thumbnails?: ThumbnailSet[]
-	
+		thumbnails?: ThumbnailSet[]
+
 	    /** The list of previous versions of the item. For more info, see [getting previous versions][]. Read-only. Nullable. */
-		        versions?: DriveItemVersion[]
-	
-		        workbook?: Workbook
-	
+		versions?: DriveItemVersion[]
+
+		workbook?: Workbook
+
 }
 
 export interface List extends BaseItem {
 
 	    /** The displayable title of the list. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Provides additional details about the list. */
-		        list?: ListInfo
-	
-		        sharepointIds?: SharepointIds
-	
+		list?: ListInfo
+
+		sharepointIds?: SharepointIds
+
 	    /** If present, indicates that this is a system-managed list. Read-only. */
-		        system?: SystemFacet
-	
-		        columns?: ColumnDefinition[]
-	
-		        contentTypes?: ContentType[]
-	
+		system?: SystemFacet
+
+		columns?: ColumnDefinition[]
+
+		contentTypes?: ContentType[]
+
 	    /** Only present on document libraries. Allows access to the list as a [drive][] resource with [driveItems][driveItem]. */
-		        drive?: Drive
-	
+		drive?: Drive
+
 	    /** All items contained in the list. */
-		        items?: ListItem[]
-	
+		items?: ListItem[]
+
 }
 
 export interface ListItem extends BaseItem {
 
 	    /** The content type of this list item */
-		        contentType?: ContentTypeInfo
-	
-		        sharepointIds?: SharepointIds
-	
+		contentType?: ContentTypeInfo
+
+		sharepointIds?: SharepointIds
+
 	    /** For document libraries, the driveItem relationship exposes the listItem as a [driveItem][] */
-		        driveItem?: DriveItem
-	
-		        fields?: FieldValueSet
-	
+		driveItem?: DriveItem
+
+		fields?: FieldValueSet
+
 	    /** The list of previous versions of the list item. */
-		        versions?: ListItemVersion[]
-	
+		versions?: ListItemVersion[]
+
 }
 
 export interface Permission extends Entity {
 
 	    /** For user type permissions, the details of the users & applications for this permission. Read-only. */
-		        grantedTo?: IdentitySet
-	
+		grantedTo?: IdentitySet
+
 	    /** Provides a reference to the ancestor of the current permission, if it is inherited from an ancestor. Read-only. */
-		        inheritedFrom?: ItemReference
-	
+		inheritedFrom?: ItemReference
+
 	    /** Details of any associated sharing invitation for this permission. Read-only. */
-		        invitation?: SharingInvitation
-	
+		invitation?: SharingInvitation
+
 	    /** Provides the link details of the current permission, if it is a link type permissions. Read-only. */
-		        link?: SharingLink
-	
-		        roles?: string[]
-	
+		link?: SharingLink
+
+		roles?: string[]
+
 	    /** A unique token that can be used to access this shared item via the **shares** API. Read-only. */
-		        shareId?: string
-	
+		shareId?: string
+
 }
 
 export interface ThumbnailSet extends Entity {
 
 	    /** A 1920x1920 scaled thumbnail. */
-		        large?: Thumbnail
-	
+		large?: Thumbnail
+
 	    /** A 176x176 scaled thumbnail. */
-		        medium?: Thumbnail
-	
+		medium?: Thumbnail
+
 	    /** A 48x48 cropped thumbnail. */
-		        small?: Thumbnail
-	
+		small?: Thumbnail
+
 	    /** A custom thumbnail image or the original image used to generate other thumbnails. */
-		        source?: Thumbnail
-	
+		source?: Thumbnail
+
 }
 
 export interface DriveItemVersion extends BaseItemVersion {
 
-		        content?: any
-	
-		        size?: number
-	
+		content?: any
+
+		size?: number
+
 }
 
 export interface Workbook extends Entity {
 
-		        application?: WorkbookApplication
-	
-		        names?: WorkbookNamedItem[]
-	
-		        tables?: WorkbookTable[]
-	
-		        worksheets?: WorkbookWorksheet[]
-	
-		        functions?: WorkbookFunctions
-	
+		application?: WorkbookApplication
+
+		names?: WorkbookNamedItem[]
+
+		tables?: WorkbookTable[]
+
+		worksheets?: WorkbookWorksheet[]
+
+		functions?: WorkbookFunctions
+
 }
 
 export interface FieldValueSet extends Entity {
@@ -2305,106 +2358,106 @@ export interface FieldValueSet extends Entity {
 export interface ListItemVersion extends BaseItemVersion {
 
 	    /** A collection of the fields and values for this version of the list item. */
-		        fields?: FieldValueSet
-	
+		fields?: FieldValueSet
+
 }
 
 export interface SharedDriveItem extends BaseItem {
 
 	    /** Information about the owner of the shared item being referenced. */
-		        owner?: IdentitySet
-	
+		owner?: IdentitySet
+
 	    /** Used to access the underlying driveItem */
-		        driveItem?: DriveItem
-	
+		driveItem?: DriveItem
+
 	    /** All driveItems contained in the sharing root. This collection cannot be enumerated. */
-		        items?: DriveItem[]
-	
+		items?: DriveItem[]
+
 	    /** Used to access the underlying list */
-		        list?: List
-	
+		list?: List
+
 	    /** Used to access the underlying listItem */
-		        listItem?: ListItem
-	
-		        root?: DriveItem
-	
+		listItem?: ListItem
+
+		root?: DriveItem
+
 	    /** Used to access the underlying site */
-		        site?: Site
-	
+		site?: Site
+
 }
 
 export interface WorkbookApplication extends Entity {
 
-		        calculationMode: string
-	
+		calculationMode?: string
+
 }
 
 export interface WorkbookNamedItem extends Entity {
 
-		        comment?: string
-	
-		        name?: string
-	
-		        scope: string
-	
-		        type?: string
-	
-		        value?: any
-	
-		        visible: boolean
-	
-		        worksheet?: WorkbookWorksheet
-	
+		comment?: string
+
+		name?: string
+
+		scope?: string
+
+		type?: string
+
+		value?: any
+
+		visible?: boolean
+
+		worksheet?: WorkbookWorksheet
+
 }
 
 export interface WorkbookTable extends Entity {
 
-		        highlightFirstColumn: boolean
-	
-		        highlightLastColumn: boolean
-	
-		        name?: string
-	
-		        showBandedColumns: boolean
-	
-		        showBandedRows: boolean
-	
-		        showFilterButton: boolean
-	
-		        showHeaders: boolean
-	
-		        showTotals: boolean
-	
-		        style?: string
-	
-		        columns?: WorkbookTableColumn[]
-	
-		        rows?: WorkbookTableRow[]
-	
-		        sort?: WorkbookTableSort
-	
-		        worksheet?: WorkbookWorksheet
-	
+		highlightFirstColumn?: boolean
+
+		highlightLastColumn?: boolean
+
+		name?: string
+
+		showBandedColumns?: boolean
+
+		showBandedRows?: boolean
+
+		showFilterButton?: boolean
+
+		showHeaders?: boolean
+
+		showTotals?: boolean
+
+		style?: string
+
+		columns?: WorkbookTableColumn[]
+
+		rows?: WorkbookTableRow[]
+
+		sort?: WorkbookTableSort
+
+		worksheet?: WorkbookWorksheet
+
 }
 
 export interface WorkbookWorksheet extends Entity {
 
-		        name?: string
-	
-		        position: number
-	
-		        visibility: string
-	
-		        charts?: WorkbookChart[]
-	
-		        names?: WorkbookNamedItem[]
-	
-		        pivotTables?: WorkbookPivotTable[]
-	
-		        protection?: WorkbookWorksheetProtection
-	
-		        tables?: WorkbookTable[]
-	
+		name?: string
+
+		position?: number
+
+		visibility?: string
+
+		charts?: WorkbookChart[]
+
+		names?: WorkbookNamedItem[]
+
+		pivotTables?: WorkbookPivotTable[]
+
+		protection?: WorkbookWorksheetProtection
+
+		tables?: WorkbookTable[]
+
 }
 
 export interface WorkbookFunctions extends Entity {
@@ -2413,104 +2466,104 @@ export interface WorkbookFunctions extends Entity {
 
 export interface WorkbookChart extends Entity {
 
-		        height: number
-	
-		        left: number
-	
-		        name?: string
-	
-		        top: number
-	
-		        width: number
-	
-		        axes?: WorkbookChartAxes
-	
-		        dataLabels?: WorkbookChartDataLabels
-	
-		        format?: WorkbookChartAreaFormat
-	
-		        legend?: WorkbookChartLegend
-	
-		        series?: WorkbookChartSeries[]
-	
-		        title?: WorkbookChartTitle
-	
-		        worksheet?: WorkbookWorksheet
-	
+		height?: number
+
+		left?: number
+
+		name?: string
+
+		top?: number
+
+		width?: number
+
+		axes?: WorkbookChartAxes
+
+		dataLabels?: WorkbookChartDataLabels
+
+		format?: WorkbookChartAreaFormat
+
+		legend?: WorkbookChartLegend
+
+		series?: WorkbookChartSeries[]
+
+		title?: WorkbookChartTitle
+
+		worksheet?: WorkbookWorksheet
+
 }
 
 export interface WorkbookChartAxes extends Entity {
 
-		        categoryAxis?: WorkbookChartAxis
-	
-		        seriesAxis?: WorkbookChartAxis
-	
-		        valueAxis?: WorkbookChartAxis
-	
+		categoryAxis?: WorkbookChartAxis
+
+		seriesAxis?: WorkbookChartAxis
+
+		valueAxis?: WorkbookChartAxis
+
 }
 
 export interface WorkbookChartDataLabels extends Entity {
 
-		        position?: string
-	
-		        separator?: string
-	
-		        showBubbleSize?: boolean
-	
-		        showCategoryName?: boolean
-	
-		        showLegendKey?: boolean
-	
-		        showPercentage?: boolean
-	
-		        showSeriesName?: boolean
-	
-		        showValue?: boolean
-	
-		        format?: WorkbookChartDataLabelFormat
-	
+		position?: string
+
+		separator?: string
+
+		showBubbleSize?: boolean
+
+		showCategoryName?: boolean
+
+		showLegendKey?: boolean
+
+		showPercentage?: boolean
+
+		showSeriesName?: boolean
+
+		showValue?: boolean
+
+		format?: WorkbookChartDataLabelFormat
+
 }
 
 export interface WorkbookChartAreaFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
-		        font?: WorkbookChartFont
-	
+		fill?: WorkbookChartFill
+
+		font?: WorkbookChartFont
+
 }
 
 export interface WorkbookChartLegend extends Entity {
 
-		        overlay?: boolean
-	
-		        position?: string
-	
-		        visible: boolean
-	
-		        format?: WorkbookChartLegendFormat
-	
+		overlay?: boolean
+
+		position?: string
+
+		visible?: boolean
+
+		format?: WorkbookChartLegendFormat
+
 }
 
 export interface WorkbookChartSeries extends Entity {
 
-		        name?: string
-	
-		        format?: WorkbookChartSeriesFormat
-	
-		        points?: WorkbookChartPoint[]
-	
+		name?: string
+
+		format?: WorkbookChartSeriesFormat
+
+		points?: WorkbookChartPoint[]
+
 }
 
 export interface WorkbookChartTitle extends Entity {
 
-		        overlay?: boolean
-	
-		        text?: string
-	
-		        visible: boolean
-	
-		        format?: WorkbookChartTitleFormat
-	
+		overlay?: boolean
+
+		text?: string
+
+		visible?: boolean
+
+		format?: WorkbookChartTitleFormat
+
 }
 
 export interface WorkbookChartFill extends Entity {
@@ -2519,226 +2572,226 @@ export interface WorkbookChartFill extends Entity {
 
 export interface WorkbookChartFont extends Entity {
 
-		        bold?: boolean
-	
-		        color?: string
-	
-		        italic?: boolean
-	
-		        name?: string
-	
-		        size?: number
-	
-		        underline?: string
-	
+		bold?: boolean
+
+		color?: string
+
+		italic?: boolean
+
+		name?: string
+
+		size?: number
+
+		underline?: string
+
 }
 
 export interface WorkbookChartAxis extends Entity {
 
-		        majorUnit?: any
-	
-		        maximum?: any
-	
-		        minimum?: any
-	
-		        minorUnit?: any
-	
-		        format?: WorkbookChartAxisFormat
-	
-		        majorGridlines?: WorkbookChartGridlines
-	
-		        minorGridlines?: WorkbookChartGridlines
-	
-		        title?: WorkbookChartAxisTitle
-	
+		majorUnit?: any
+
+		maximum?: any
+
+		minimum?: any
+
+		minorUnit?: any
+
+		format?: WorkbookChartAxisFormat
+
+		majorGridlines?: WorkbookChartGridlines
+
+		minorGridlines?: WorkbookChartGridlines
+
+		title?: WorkbookChartAxisTitle
+
 }
 
 export interface WorkbookChartAxisFormat extends Entity {
 
-		        font?: WorkbookChartFont
-	
-		        line?: WorkbookChartLineFormat
-	
+		font?: WorkbookChartFont
+
+		line?: WorkbookChartLineFormat
+
 }
 
 export interface WorkbookChartGridlines extends Entity {
 
-		        visible: boolean
-	
-		        format?: WorkbookChartGridlinesFormat
-	
+		visible?: boolean
+
+		format?: WorkbookChartGridlinesFormat
+
 }
 
 export interface WorkbookChartAxisTitle extends Entity {
 
-		        text?: string
-	
-		        visible: boolean
-	
-		        format?: WorkbookChartAxisTitleFormat
-	
+		text?: string
+
+		visible?: boolean
+
+		format?: WorkbookChartAxisTitleFormat
+
 }
 
 export interface WorkbookChartLineFormat extends Entity {
 
-		        color?: string
-	
+		color?: string
+
 }
 
 export interface WorkbookChartAxisTitleFormat extends Entity {
 
-		        font?: WorkbookChartFont
-	
+		font?: WorkbookChartFont
+
 }
 
 export interface WorkbookChartDataLabelFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
-		        font?: WorkbookChartFont
-	
+		fill?: WorkbookChartFill
+
+		font?: WorkbookChartFont
+
 }
 
 export interface WorkbookChartGridlinesFormat extends Entity {
 
-		        line?: WorkbookChartLineFormat
-	
+		line?: WorkbookChartLineFormat
+
 }
 
 export interface WorkbookChartLegendFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
-		        font?: WorkbookChartFont
-	
+		fill?: WorkbookChartFill
+
+		font?: WorkbookChartFont
+
 }
 
 export interface WorkbookChartPoint extends Entity {
 
-		        value?: any
-	
-		        format?: WorkbookChartPointFormat
-	
+		value?: any
+
+		format?: WorkbookChartPointFormat
+
 }
 
 export interface WorkbookChartPointFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
+		fill?: WorkbookChartFill
+
 }
 
 export interface WorkbookChartSeriesFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
-		        line?: WorkbookChartLineFormat
-	
+		fill?: WorkbookChartFill
+
+		line?: WorkbookChartLineFormat
+
 }
 
 export interface WorkbookChartTitleFormat extends Entity {
 
-		        fill?: WorkbookChartFill
-	
-		        font?: WorkbookChartFont
-	
+		fill?: WorkbookChartFill
+
+		font?: WorkbookChartFont
+
 }
 
 export interface WorkbookFilter extends Entity {
 
-		        criteria?: WorkbookFilterCriteria
-	
+		criteria?: WorkbookFilterCriteria
+
 }
 
 export interface WorkbookFormatProtection extends Entity {
 
-		        formulaHidden?: boolean
-	
-		        locked?: boolean
-	
+		formulaHidden?: boolean
+
+		locked?: boolean
+
 }
 
 export interface WorkbookFunctionResult extends Entity {
 
-		        error?: string
-	
-		        value?: any
-	
+		error?: string
+
+		value?: any
+
 }
 
 export interface WorkbookPivotTable extends Entity {
 
 	    /** Name of the PivotTable. */
-		        name?: string
-	
+		name?: string
+
 	    /** The worksheet containing the current PivotTable. Read-only. */
-		        worksheet?: WorkbookWorksheet
-	
+		worksheet?: WorkbookWorksheet
+
 }
 
 export interface WorkbookRange extends Entity {
 
-		        address?: string
-	
-		        addressLocal?: string
-	
-		        cellCount: number
-	
-		        columnCount: number
-	
-		        columnHidden?: boolean
-	
-		        columnIndex: number
-	
-		        formulas?: any
-	
-		        formulasLocal?: any
-	
-		        formulasR1C1?: any
-	
-		        hidden?: boolean
-	
-		        numberFormat?: any
-	
-		        rowCount: number
-	
-		        rowHidden?: boolean
-	
-		        rowIndex: number
-	
-		        text?: any
-	
-		        valueTypes?: any
-	
-		        values?: any
-	
-		        format?: WorkbookRangeFormat
-	
-		        sort?: WorkbookRangeSort
-	
-		        worksheet?: WorkbookWorksheet
-	
+		address?: string
+
+		addressLocal?: string
+
+		cellCount?: number
+
+		columnCount?: number
+
+		columnHidden?: boolean
+
+		columnIndex?: number
+
+		formulas?: any
+
+		formulasLocal?: any
+
+		formulasR1C1?: any
+
+		hidden?: boolean
+
+		numberFormat?: any
+
+		rowCount?: number
+
+		rowHidden?: boolean
+
+		rowIndex?: number
+
+		text?: any
+
+		valueTypes?: any
+
+		values?: any
+
+		format?: WorkbookRangeFormat
+
+		sort?: WorkbookRangeSort
+
+		worksheet?: WorkbookWorksheet
+
 }
 
 export interface WorkbookRangeFormat extends Entity {
 
-		        columnWidth?: number
-	
-		        horizontalAlignment?: string
-	
-		        rowHeight?: number
-	
-		        verticalAlignment?: string
-	
-		        wrapText?: boolean
-	
-		        borders?: WorkbookRangeBorder[]
-	
-		        fill?: WorkbookRangeFill
-	
-		        font?: WorkbookRangeFont
-	
-		        protection?: WorkbookFormatProtection
-	
+		columnWidth?: number
+
+		horizontalAlignment?: string
+
+		rowHeight?: number
+
+		verticalAlignment?: string
+
+		wrapText?: boolean
+
+		borders?: WorkbookRangeBorder[]
+
+		fill?: WorkbookRangeFill
+
+		font?: WorkbookRangeFont
+
+		protection?: WorkbookFormatProtection
+
 }
 
 export interface WorkbookRangeSort extends Entity {
@@ -2747,500 +2800,500 @@ export interface WorkbookRangeSort extends Entity {
 
 export interface WorkbookRangeBorder extends Entity {
 
-		        color?: string
-	
-		        sideIndex?: string
-	
-		        style?: string
-	
-		        weight?: string
-	
+		color?: string
+
+		sideIndex?: string
+
+		style?: string
+
+		weight?: string
+
 }
 
 export interface WorkbookRangeFill extends Entity {
 
-		        color?: string
-	
+		color?: string
+
 }
 
 export interface WorkbookRangeFont extends Entity {
 
-		        bold?: boolean
-	
-		        color?: string
-	
-		        italic?: boolean
-	
-		        name?: string
-	
-		        size?: number
-	
-		        underline?: string
-	
+		bold?: boolean
+
+		color?: string
+
+		italic?: boolean
+
+		name?: string
+
+		size?: number
+
+		underline?: string
+
 }
 
 export interface WorkbookRangeView extends Entity {
 
-		        cellAddresses?: any
-	
+		cellAddresses?: any
+
 	    /** Returns the number of visible columns. Read-only. */
-		        columnCount: number
-	
+		columnCount?: number
+
 	    /** Represents the formula in A1-style notation. */
-		        formulas?: any
-	
+		formulas?: any
+
 	    /** Represents the formula in A1-style notation, in the user's language and number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. */
-		        formulasLocal?: any
-	
+		formulasLocal?: any
+
 	    /** Represents the formula in R1C1-style notation. */
-		        formulasR1C1?: any
-	
+		formulasR1C1?: any
+
 	    /** Index of the range. */
-		        index: number
-	
+		index?: number
+
 	    /** Represents Excel's number format code for the given cell. Read-only. */
-		        numberFormat?: any
-	
+		numberFormat?: any
+
 	    /** Returns the number of visible rows. Read-only. */
-		        rowCount: number
-	
+		rowCount?: number
+
 	    /** Text values of the specified range. The Text value will not depend on the cell width. The # sign substitution that happens in Excel UI will not affect the text value returned by the API. Read-only. */
-		        text?: any
-	
+		text?: any
+
 	    /** Represents the type of data of each cell. Read-only. Possible values are: Unknown, Empty, String, Integer, Double, Boolean, Error. */
-		        valueTypes?: any
-	
+		valueTypes?: any
+
 	    /** Represents the raw values of the specified range view. The data returned could be of type string, number, or a boolean. Cell that contain an error will return the error string. */
-		        values?: any
-	
+		values?: any
+
 	    /** Represents a collection of range views associated with the range. Read-only. Read-only. */
-		        rows?: WorkbookRangeView[]
-	
+		rows?: WorkbookRangeView[]
+
 }
 
 export interface WorkbookTableColumn extends Entity {
 
-		        index: number
-	
-		        name?: string
-	
-		        values?: any
-	
-		        filter?: WorkbookFilter
-	
+		index?: number
+
+		name?: string
+
+		values?: any
+
+		filter?: WorkbookFilter
+
 }
 
 export interface WorkbookTableRow extends Entity {
 
-		        index: number
-	
-		        values?: any
-	
+		index?: number
+
+		values?: any
+
 }
 
 export interface WorkbookTableSort extends Entity {
 
-		        fields?: WorkbookSortField[]
-	
-		        matchCase: boolean
-	
-		        method: string
-	
+		fields?: WorkbookSortField[]
+
+		matchCase?: boolean
+
+		method?: string
+
 }
 
 export interface WorkbookWorksheetProtection extends Entity {
 
-		        options?: WorkbookWorksheetProtectionOptions
-	
-		        protected: boolean
-	
+		options?: WorkbookWorksheetProtectionOptions
+
+		protected?: boolean
+
 }
 
 export interface Subscription extends Entity {
 
 	    /** Specifies the resource that will be monitored for changes. Do not include the base URL (https://graph.microsoft.com/{version}/). */
-		        resource: string
-	
+		resource?: string
+
 	    /** Indicates the type of change in the subscribed resource that will raise a notification. The supported values are: created, updated, deleted. Multiple values can be combined using a comma-separated list. Drive root Item notifications require the use of updated only. */
-		        changeType: string
-	
+		changeType?: string
+
 	    /** Specifies the value of the clientState property sent by the service in each notification. The maximum length is 255 characters. The client can check that the notification came from the service by comparing the value of the clientState property sent with the subscription with the value of the clientState property received with each notification. */
-		        clientState?: string
-	
+		clientState?: string
+
 	    /** The URL of the endpoint that will receive the notifications. This URL has to make use of the HTTPS protocol. */
-		        notificationUrl: string
-	
+		notificationUrl?: string
+
 	    /** Specifies the date and time when the webhook subscription expires. The time is in UTC, and can be an amount of time from subscription creation that varies for the resource subscribed to.  See the table below for maximum supported subscription length of time. */
-		        expirationDateTime: string
-	
+		expirationDateTime?: string
+
 	    /** Identifier of the application used to create the subscription. */
-		        applicationId?: string
-	
+		applicationId?: string
+
 	    /** Identifier of the user or service principal that created the subscription.If the app used delegated permissions to create the subscription, this field contains the id of the signed-in user the app called on behalf of.If the app used application permissions, this field contains the id of the service principal corresponding to the app. */
-		        creatorId?: string
-	
+		creatorId?: string
+
 }
 
 export interface Invitation extends Entity {
 
-		        invitedUserDisplayName?: string
-	
-		        invitedUserType?: string
-	
-		        invitedUserEmailAddress: string
-	
-		        invitedUserMessageInfo?: InvitedUserMessageInfo
-	
-		        sendInvitationMessage?: boolean
-	
-		        inviteRedirectUrl: string
-	
-		        inviteRedeemUrl?: string
-	
-		        status?: string
-	
-		        invitedUser?: User
-	
+		invitedUserDisplayName?: string
+
+		invitedUserType?: string
+
+		invitedUserEmailAddress?: string
+
+		invitedUserMessageInfo?: InvitedUserMessageInfo
+
+		sendInvitationMessage?: boolean
+
+		inviteRedirectUrl?: string
+
+		inviteRedeemUrl?: string
+
+		status?: string
+
+		invitedUser?: User
+
 }
 
 export interface PlannerTask extends Entity {
 
 	    /** Identity of the user that created the task. */
-		        createdBy?: IdentitySet
-	
+		createdBy?: IdentitySet
+
 	    /** Plan ID to which the task belongs. */
-		        planId?: string
-	
+		planId?: string
+
 	    /** Bucket ID to which the task belongs. The bucket needs to be in the plan that the task is in. It is 28 characters long and case sensitive. Format validation is done on the service. */
-		        bucketId?: string
-	
+		bucketId?: string
+
 	    /** Title of the task. */
-		        title: string
-	
+		title?: string
+
 	    /** Hint used to order items of this type in a list view. The format is defined as outlined here. */
-		        orderHint?: string
-	
+		orderHint?: string
+
 	    /** Hint used to order items of this type in a list view. The format is defined as outlined here. */
-		        assigneePriority?: string
-	
+		assigneePriority?: string
+
 	    /** Percentage of task completion. When set to 100, the task is considered completed. */
-		        percentComplete?: number
-	
+		percentComplete?: number
+
 	    /** Date and time at which the task starts. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        startDateTime?: string
-	
+		startDateTime?: string
+
 	    /** Read-only. Date and time at which the task is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        createdDateTime?: string
-	
+		createdDateTime?: string
+
 	    /** Date and time at which the task is due. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        dueDateTime?: string
-	
+		dueDateTime?: string
+
 	    /** Read-only. Value is true if the details object of the task has a non-empty description and false otherwise. */
-		        hasDescription?: boolean
-	
+		hasDescription?: boolean
+
 	    /** This sets the type of preview that shows up on the task. Possible values are: automatic, noPreview, checklist, description, reference. */
-		        previewType?: PlannerPreviewType
-	
+		previewType?: PlannerPreviewType
+
 	    /** Read-only. Date and time at which the 'percentComplete' of the task is set to '100'. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        completedDateTime?: string
-	
+		completedDateTime?: string
+
 	    /** Identity of the user that completed the task. */
-		        completedBy?: IdentitySet
-	
+		completedBy?: IdentitySet
+
 	    /** Number of external references that exist on the task. */
-		        referenceCount?: number
-	
+		referenceCount?: number
+
 	    /** Number of checklist items that are present on the task. */
-		        checklistItemCount?: number
-	
+		checklistItemCount?: number
+
 	    /** Number of checklist items with value set to 'false', representing incomplete items. */
-		        activeChecklistItemCount?: number
-	
+		activeChecklistItemCount?: number
+
 	    /** The categories to which the task has been applied. See applied Categories for possible values. */
-		        appliedCategories?: PlannerAppliedCategories
-	
+		appliedCategories?: PlannerAppliedCategories
+
 	    /** The set of assignees the task is assigned to. */
-		        assignments?: PlannerAssignments
-	
+		assignments?: PlannerAssignments
+
 	    /** Thread ID of the conversation on the task. This is the ID of the conversation thread object created in the group. */
-		        conversationThreadId?: string
-	
+		conversationThreadId?: string
+
 	    /** Read-only. Nullable. Additional details about the task. */
-		        details?: PlannerTaskDetails
-	
+		details?: PlannerTaskDetails
+
 	    /** Read-only. Nullable. Used to render the task correctly in the task board view when grouped by assignedTo. */
-		        assignedToTaskBoardFormat?: PlannerAssignedToTaskBoardTaskFormat
-	
+		assignedToTaskBoardFormat?: PlannerAssignedToTaskBoardTaskFormat
+
 	    /** Read-only. Nullable. Used to render the task correctly in the task board view when grouped by progress. */
-		        progressTaskBoardFormat?: PlannerProgressTaskBoardTaskFormat
-	
+		progressTaskBoardFormat?: PlannerProgressTaskBoardTaskFormat
+
 	    /** Read-only. Nullable. Used to render the task correctly in the task board view when grouped by bucket. */
-		        bucketTaskBoardFormat?: PlannerBucketTaskBoardTaskFormat
-	
+		bucketTaskBoardFormat?: PlannerBucketTaskBoardTaskFormat
+
 }
 
 export interface PlannerPlan extends Entity {
 
 	    /** Read-only. The user who created the plan. */
-		        createdBy?: IdentitySet
-	
+		createdBy?: IdentitySet
+
 	    /** Read-only. Date and time at which the plan is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-		        createdDateTime?: string
-	
+		createdDateTime?: string
+
 	    /** ID of the Group that owns the plan. A valid group must exist before this field can be set. Once set, this can only be updated by the owner. */
-		        owner?: string
-	
+		owner?: string
+
 	    /** Required. Title of the plan. */
-		        title: string
-	
+		title?: string
+
 	    /** Read-only. Nullable. Collection of tasks in the plan. */
-		        tasks?: PlannerTask[]
-	
+		tasks?: PlannerTask[]
+
 	    /** Read-only. Nullable. Collection of buckets in the plan. */
-		        buckets?: PlannerBucket[]
-	
+		buckets?: PlannerBucket[]
+
 	    /** Read-only. Nullable. Additional details about the plan. */
-		        details?: PlannerPlanDetails
-	
+		details?: PlannerPlanDetails
+
 }
 
 export interface Planner extends Entity {
 
 	    /** Read-only. Nullable. Returns a collection of the specified tasks */
-		        tasks?: PlannerTask[]
-	
+		tasks?: PlannerTask[]
+
 	    /** Read-only. Nullable. Returns a collection of the specified plans */
-		        plans?: PlannerPlan[]
-	
+		plans?: PlannerPlan[]
+
 	    /** Read-only. Nullable. Returns a collection of the specified buckets */
-		        buckets?: PlannerBucket[]
-	
+		buckets?: PlannerBucket[]
+
 }
 
 export interface PlannerBucket extends Entity {
 
 	    /** Name of the bucket. */
-		        name: string
-	
+		name?: string
+
 	    /** Plan ID to which the bucket belongs. */
-		        planId?: string
-	
+		planId?: string
+
 	    /** Hint used to order items of this type in a list view. The format is defined as outlined here. */
-		        orderHint?: string
-	
+		orderHint?: string
+
 	    /** Read-only. Nullable. The collection of tasks in the bucket. */
-		        tasks?: PlannerTask[]
-	
+		tasks?: PlannerTask[]
+
 }
 
 export interface PlannerTaskDetails extends Entity {
 
 	    /** Description of the task */
-		        description?: string
-	
+		description?: string
+
 	    /** This sets the type of preview that shows up on the task. Possible values are: automatic, noPreview, checklist, description, reference. When set to automatic the displayed preview is chosen by the app viewing the task. */
-		        previewType?: PlannerPreviewType
-	
+		previewType?: PlannerPreviewType
+
 	    /** The collection of references on the task. */
-		        references?: PlannerExternalReferences
-	
+		references?: PlannerExternalReferences
+
 	    /** The collection of checklist items on the task. */
-		        checklist?: PlannerChecklistItems
-	
+		checklist?: PlannerChecklistItems
+
 }
 
 export interface PlannerAssignedToTaskBoardTaskFormat extends Entity {
 
 	    /** Hint value used to order the task on the AssignedTo view of the Task Board when the task is not assigned to anyone, or if the orderHintsByAssignee dictionary does not provide an order hint for the user the task is assigned to. The format is defined as outlined here. */
-		        unassignedOrderHint?: string
-	
+		unassignedOrderHint?: string
+
 	    /** Dictionary of hints used to order tasks on the AssignedTo view of the Task Board. The key of each entry is one of the users the task is assigned to and the value is the order hint. The format of each value is defined as outlined here. */
-		        orderHintsByAssignee?: PlannerOrderHintsByAssignee
-	
+		orderHintsByAssignee?: PlannerOrderHintsByAssignee
+
 }
 
 export interface PlannerProgressTaskBoardTaskFormat extends Entity {
 
 	    /** Hint value used to order the task on the Progress view of the Task Board. The format is defined as outlined here. */
-		        orderHint?: string
-	
+		orderHint?: string
+
 }
 
 export interface PlannerBucketTaskBoardTaskFormat extends Entity {
 
 	    /** Hint used to order tasks in the Bucket view of the Task Board. The format is defined as outlined here. */
-		        orderHint?: string
-	
+		orderHint?: string
+
 }
 
 export interface PlannerPlanDetails extends Entity {
 
 	    /** Set of user ids that this plan is shared with. If you are leveraging Office 365 Groups, use the Groups API to manage group membership to share the group's plan. You can also add existing members of the group to this collection though it is not required for them to access the plan owned by the group. */
-		        sharedWith?: PlannerUserIds
-	
+		sharedWith?: PlannerUserIds
+
 	    /** An object that specifies the descriptions of the six categories that can be associated with tasks in the plan */
-		        categoryDescriptions?: PlannerCategoryDescriptions
-	
+		categoryDescriptions?: PlannerCategoryDescriptions
+
 }
 
 export interface OnenoteEntityBaseModel extends Entity {
 
-		        self?: string
-	
+		self?: string
+
 }
 
 export interface OnenoteEntitySchemaObjectModel extends OnenoteEntityBaseModel {
 
-		        createdDateTime?: string
-	
+		createdDateTime?: string
+
 }
 
 export interface OnenoteEntityHierarchyModel extends OnenoteEntitySchemaObjectModel {
 
-		        displayName?: string
-	
-		        createdBy?: IdentitySet
-	
-		        lastModifiedBy?: IdentitySet
-	
-		        lastModifiedDateTime?: string
-	
+		displayName?: string
+
+		createdBy?: IdentitySet
+
+		lastModifiedBy?: IdentitySet
+
+		lastModifiedDateTime?: string
+
 }
 
 export interface Notebook extends OnenoteEntityHierarchyModel {
 
 	    /** Indicates whether this is the user's default notebook. Read-only. */
-		        isDefault?: boolean
-	
+		isDefault?: boolean
+
 	    /** Possible values are: Owner, Contributor, Reader, None. Owner represents owner-level access to the notebook. Contributor represents read/write access to the notebook. Reader represents read-only access to the notebook. Read-only. */
-		        userRole?: OnenoteUserRole
-	
+		userRole?: OnenoteUserRole
+
 	    /** Indicates whether the notebook is shared. If true, the contents of the notebook can be seen by people other than the owner. Read-only. */
-		        isShared?: boolean
-	
+		isShared?: boolean
+
 	    /** The URL for the sections navigation property, which returns all the sections in the notebook. Read-only. */
-		        sectionsUrl?: string
-	
+		sectionsUrl?: string
+
 	    /** The URL for the sectionGroups navigation property, which returns all the section groups in the notebook. Read-only. */
-		        sectionGroupsUrl?: string
-	
+		sectionGroupsUrl?: string
+
 	    /** Links for opening the notebook. The oneNoteClientURL link opens the notebook in the OneNote native client if it's installed. The oneNoteWebURL link opens the notebook in OneNote Online. */
-		        links?: NotebookLinks
-	
+		links?: NotebookLinks
+
 	    /** The sections in the notebook. Read-only. Nullable. */
-		        sections?: OnenoteSection[]
-	
+		sections?: OnenoteSection[]
+
 	    /** The section groups in the notebook. Read-only. Nullable. */
-		        sectionGroups?: SectionGroup[]
-	
+		sectionGroups?: SectionGroup[]
+
 }
 
 export interface OnenoteSection extends OnenoteEntityHierarchyModel {
 
 	    /** Indicates whether this is the user's default section. Read-only. */
-		        isDefault?: boolean
-	
+		isDefault?: boolean
+
 	    /** Links for opening the section. The oneNoteClientURL link opens the section in the OneNote native client if it's installed. The oneNoteWebURL link opens the section in OneNote Online. */
-		        links?: SectionLinks
-	
+		links?: SectionLinks
+
 	    /** The pages endpoint where you can get details for all the pages in the section. Read-only. */
-		        pagesUrl?: string
-	
+		pagesUrl?: string
+
 	    /** The notebook that contains the section.  Read-only. */
-		        parentNotebook?: Notebook
-	
+		parentNotebook?: Notebook
+
 	    /** The section group that contains the section.  Read-only. */
-		        parentSectionGroup?: SectionGroup
-	
+		parentSectionGroup?: SectionGroup
+
 	    /** The collection of pages in the section.  Read-only. Nullable. */
-		        pages?: OnenotePage[]
-	
+		pages?: OnenotePage[]
+
 }
 
 export interface SectionGroup extends OnenoteEntityHierarchyModel {
 
-		        sectionsUrl?: string
-	
-		        sectionGroupsUrl?: string
-	
-		        parentNotebook?: Notebook
-	
-		        parentSectionGroup?: SectionGroup
-	
-		        sections?: OnenoteSection[]
-	
-		        sectionGroups?: SectionGroup[]
-	
+		sectionsUrl?: string
+
+		sectionGroupsUrl?: string
+
+		parentNotebook?: Notebook
+
+		parentSectionGroup?: SectionGroup
+
+		sections?: OnenoteSection[]
+
+		sectionGroups?: SectionGroup[]
+
 }
 
 export interface OnenotePage extends OnenoteEntitySchemaObjectModel {
 
 	    /** The title of the page. */
-		        title?: string
-	
+		title?: string
+
 	    /** The unique identifier of the application that created the page. Read-only. */
-		        createdByAppId?: string
-	
+		createdByAppId?: string
+
 	    /** Links for opening the page. The oneNoteClientURL link opens the page in the OneNote native client if it 's installed. The oneNoteWebUrl link opens the page in OneNote Online. Read-only. */
-		        links?: PageLinks
-	
+		links?: PageLinks
+
 	    /** The URL for the page's HTML content.  Read-only. */
-		        contentUrl?: string
-	
+		contentUrl?: string
+
 	    /** The page's HTML content. */
-		        content?: any
-	
+		content?: any
+
 	    /** The date and time when the page was last modified. The timestamp represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. */
-		        lastModifiedDateTime?: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The indentation level of the page. Read-only. */
-		        level?: number
-	
+		level?: number
+
 	    /** The order of the page within its parent section. Read-only. */
-		        order?: number
-	
-		        userTags?: string[]
-	
+		order?: number
+
+		userTags?: string[]
+
 	    /** The section that contains the page. Read-only. */
-		        parentSection?: OnenoteSection
-	
+		parentSection?: OnenoteSection
+
 	    /** The notebook that contains the page.  Read-only. */
-		        parentNotebook?: Notebook
-	
+		parentNotebook?: Notebook
+
 }
 
 export interface OnenoteResource extends OnenoteEntityBaseModel {
 
-		        content?: any
-	
-		        contentUrl?: string
-	
+		content?: any
+
+		contentUrl?: string
+
 }
 
 export interface Operation extends Entity {
 
-		        status?: OperationStatus
-	
-		        createdDateTime?: string
-	
-		        lastActionDateTime?: string
-	
+		status?: OperationStatus
+
+		createdDateTime?: string
+
+		lastActionDateTime?: string
+
 }
 
 export interface OnenoteOperation extends Operation {
 
 	    /** The resource URI for the object. For example, the resource URI for a copied page or section. */
-		        resourceLocation?: string
-	
+		resourceLocation?: string
+
 	    /** The resource id. */
-		        resourceId?: string
-	
+		resourceId?: string
+
 	    /** The error returned by the operation. */
-		        error?: OnenoteOperationError
-	
+		error?: OnenoteOperationError
+
 	    /** The operation percent complete if the operation is still in running status */
-		        percentComplete?: string
-	
+		percentComplete?: string
+
 }
 
 export interface ReportRoot extends Entity {
@@ -3253,690 +3306,690 @@ export interface AdministrativeUnit extends DirectoryObject {
 
 export interface EducationRoot extends Entity {
 
-		        classes?: EducationClass[]
-	
-		        schools?: EducationSchool[]
-	
-		        users?: EducationUser[]
-	
-		        me?: EducationUser
-	
+		classes?: EducationClass[]
+
+		schools?: EducationSchool[]
+
+		users?: EducationUser[]
+
+		me?: EducationUser
+
 }
 
 export interface EducationClass extends Entity {
 
 	    /** Name of the class. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Mail name for sending email to all members, if this is enabled. */
-		        mailNickname: string
-	
+		mailNickname?: string
+
 	    /** Description of the class. */
-		        description?: string
-	
+		description?: string
+
 	    /** Entity who created the class */
-		        createdBy?: IdentitySet
-	
+		createdBy?: IdentitySet
+
 	    /** Class code used by the school to identify the class. */
-		        classCode?: string
-	
+		classCode?: string
+
 	    /** Name of the class in the syncing system. */
-		        externalName?: string
-	
+		externalName?: string
+
 	    /** ID of the class from the syncing system. */
-		        externalId?: string
-	
+		externalId?: string
+
 	    /** How this class was created. Possible values are: sis, manual, unknownFutureValue. */
-		        externalSource?: EducationExternalSource
-	
+		externalSource?: EducationExternalSource
+
 	    /** Term for this class. */
-		        term?: EducationTerm
-	
+		term?: EducationTerm
+
 	    /** All schools that this class is associated with. Nullable. */
-		        schools?: EducationSchool[]
-	
+		schools?: EducationSchool[]
+
 	    /** All users in the class. Nullable. */
-		        members?: EducationUser[]
-	
+		members?: EducationUser[]
+
 	    /** All teachers in the class. Nullable. */
-		        teachers?: EducationUser[]
-	
-		        group?: Group
-	
+		teachers?: EducationUser[]
+
+		group?: Group
+
 }
 
 export interface EducationOrganization extends Entity {
 
-		        displayName: string
-	
-		        description?: string
-	
-		        externalSource?: EducationExternalSource
-	
+		displayName?: string
+
+		description?: string
+
+		externalSource?: EducationExternalSource
+
 }
 
 export interface EducationSchool extends EducationOrganization {
 
 	    /** Email address of the principal. */
-		        principalEmail?: string
-	
+		principalEmail?: string
+
 	    /** Name of the principal. */
-		        principalName?: string
-	
+		principalName?: string
+
 	    /** ID of principal in syncing system. */
-		        externalPrincipalId?: string
-	
+		externalPrincipalId?: string
+
 	    /** Lowest grade taught. */
-		        lowestGrade?: string
-	
+		lowestGrade?: string
+
 	    /** Highest grade taught. */
-		        highestGrade?: string
-	
+		highestGrade?: string
+
 	    /** School Number. */
-		        schoolNumber?: string
-	
+		schoolNumber?: string
+
 	    /** ID of school in syncing system. */
-		        externalId?: string
-	
+		externalId?: string
+
 	    /** Phone number of school. */
-		        phone?: string
-	
+		phone?: string
+
 	    /** Fax number of school. */
-		        fax?: string
-	
+		fax?: string
+
 	    /** Entity who created the school. */
-		        createdBy?: IdentitySet
-	
+		createdBy?: IdentitySet
+
 	    /** Address of the school. */
-		        address?: PhysicalAddress
-	
+		address?: PhysicalAddress
+
 	    /** Classes taught at the school. Nullable. */
-		        classes?: EducationClass[]
-	
+		classes?: EducationClass[]
+
 	    /** Users in the school. Nullable. */
-		        users?: EducationUser[]
-	
+		users?: EducationUser[]
+
 }
 
 export interface EducationUser extends Entity {
 
 	    /** Default role for a user. The user's role might be different in an individual class. Possible values are: student, teacher, enum_sentinel. Supports $filter. */
-		        primaryRole: EducationUserRole
-	
+		primaryRole?: EducationUserRole
+
 	    /** The middle name of user. */
-		        middleName?: string
-	
+		middleName?: string
+
 	    /** Where this user was created from. Possible values are: sis, manual, unkownFutureValue. */
-		        externalSource?: EducationExternalSource
-	
+		externalSource?: EducationExternalSource
+
 	    /** Address where user lives. */
-		        residenceAddress?: PhysicalAddress
-	
+		residenceAddress?: PhysicalAddress
+
 	    /** Mail address of user. */
-		        mailingAddress?: PhysicalAddress
-	
+		mailingAddress?: PhysicalAddress
+
 	    /** If the primary role is student, this block will contain student specific data. */
-		        student?: EducationStudent
-	
+		student?: EducationStudent
+
 	    /** If the primary role is teacher, this block will conatin teacher specific data. */
-		        teacher?: EducationTeacher
-	
+		teacher?: EducationTeacher
+
 	    /** Entity who created the user. */
-		        createdBy?: IdentitySet
-	
-		        relatedContacts?: EducationRelatedContact[]
-	
-		        accountEnabled?: boolean
-	
-		        assignedLicenses: AssignedLicense[]
-	
-		        assignedPlans: AssignedPlan[]
-	
-		        businessPhones: string[]
-	
-		        department?: string
-	
+		createdBy?: IdentitySet
+
+		relatedContacts?: EducationRelatedContact[]
+
+		accountEnabled?: boolean
+
+		assignedLicenses?: AssignedLicense[]
+
+		assignedPlans?: AssignedPlan[]
+
+		businessPhones?: string[]
+
+		department?: string
+
 	    /** The name displayed in the address book for the user. This is usually the combination of the user's first name, middle initial, and last name. This property is required when a user is created and it cannot be cleared during updates. Supports $filter and $orderby. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The given name (first name) of the user. Supports $filter. */
-		        givenName?: string
-	
+		givenName?: string
+
 	    /** The SMTP address for the user; for example, "jeff@contoso.onmicrosoft.com". Read-Only. Supports $filter. */
-		        mail?: string
-	
-		        mailNickname?: string
-	
+		mail?: string
+
+		mailNickname?: string
+
 	    /** The primary cellular telephone number for the user. */
-		        mobilePhone?: string
-	
-		        passwordPolicies?: string
-	
-		        passwordProfile?: PasswordProfile
-	
-		        officeLocation?: string
-	
-		        preferredLanguage?: string
-	
-		        provisionedPlans: ProvisionedPlan[]
-	
-		        refreshTokensValidFromDateTime?: string
-	
-		        showInAddressList?: boolean
-	
+		mobilePhone?: string
+
+		passwordPolicies?: string
+
+		passwordProfile?: PasswordProfile
+
+		officeLocation?: string
+
+		preferredLanguage?: string
+
+		provisionedPlans?: ProvisionedPlan[]
+
+		refreshTokensValidFromDateTime?: string
+
+		showInAddressList?: boolean
+
 	    /** The user's surname (family name or last name). Supports $filter. */
-		        surname?: string
-	
-		        usageLocation?: string
-	
-		        userPrincipalName?: string
-	
-		        userType?: string
-	
+		surname?: string
+
+		usageLocation?: string
+
+		userPrincipalName?: string
+
+		userType?: string
+
 	    /** Schools to which the user belongs. Nullable. */
-		        schools?: EducationSchool[]
-	
+		schools?: EducationSchool[]
+
 	    /** Classes to which the user belongs. Nullable. */
-		        classes?: EducationClass[]
-	
-		        user?: User
-	
+		classes?: EducationClass[]
+
+		user?: User
+
 }
 
 export interface DeviceAppManagement extends Entity {
 
 	    /** The last time the apps from the Microsoft Store for Business were synced successfully for the account. */
-		        microsoftStoreForBusinessLastSuccessfulSyncDateTime: string
-	
+		microsoftStoreForBusinessLastSuccessfulSyncDateTime?: string
+
 	    /** Whether the account is enabled for syncing applications from the Microsoft Store for Business. */
-		        isEnabledForMicrosoftStoreForBusiness: boolean
-	
+		isEnabledForMicrosoftStoreForBusiness?: boolean
+
 	    /** The locale information used to sync applications from the Microsoft Store for Business. Cultures that are specific to a country/region. The names of these cultures follow RFC 4646 (Windows Vista and later). The format is -<country/regioncode2>, where  is a lowercase two-letter code derived from ISO 639-1 and <country/regioncode2> is an uppercase two-letter code derived from ISO 3166. For example, en-US for English (United States) is a specific culture. */
-		        microsoftStoreForBusinessLanguage?: string
-	
+		microsoftStoreForBusinessLanguage?: string
+
 	    /** The last time an application sync from the Microsoft Store for Business was completed. */
-		        microsoftStoreForBusinessLastCompletedApplicationSyncTime: string
-	
+		microsoftStoreForBusinessLastCompletedApplicationSyncTime?: string
+
 	    /** The mobile apps. */
-		        mobileApps?: MobileApp[]
-	
+		mobileApps?: MobileApp[]
+
 	    /** The mobile app categories. */
-		        mobileAppCategories?: MobileAppCategory[]
-	
+		mobileAppCategories?: MobileAppCategory[]
+
 	    /** The Managed Device Mobile Application Configurations. */
-		        mobileAppConfigurations?: ManagedDeviceMobileAppConfiguration[]
-	
+		mobileAppConfigurations?: ManagedDeviceMobileAppConfiguration[]
+
 	    /** List of Vpp tokens for this organization. */
-		        vppTokens?: VppToken[]
-	
+		vppTokens?: VppToken[]
+
 	    /** Managed app policies. */
-		        managedAppPolicies?: ManagedAppPolicy[]
-	
-		        iosManagedAppProtections?: IosManagedAppProtection[]
-	
+		managedAppPolicies?: ManagedAppPolicy[]
+
+		iosManagedAppProtections?: IosManagedAppProtection[]
+
 	    /** Android managed app policies. */
-		        androidManagedAppProtections?: AndroidManagedAppProtection[]
-	
+		androidManagedAppProtections?: AndroidManagedAppProtection[]
+
 	    /** Default managed app policies. */
-		        defaultManagedAppProtections?: DefaultManagedAppProtection[]
-	
+		defaultManagedAppProtections?: DefaultManagedAppProtection[]
+
 	    /** Targeted managed app configurations. */
-		        targetedManagedAppConfigurations?: TargetedManagedAppConfiguration[]
-	
+		targetedManagedAppConfigurations?: TargetedManagedAppConfiguration[]
+
 	    /** Windows information protection for apps running on devices which are MDM enrolled. */
-		        mdmWindowsInformationProtectionPolicies?: MdmWindowsInformationProtectionPolicy[]
-	
+		mdmWindowsInformationProtectionPolicies?: MdmWindowsInformationProtectionPolicy[]
+
 	    /** Windows information protection for apps running on devices which are not MDM enrolled. */
-		        windowsInformationProtectionPolicies?: WindowsInformationProtectionPolicy[]
-	
+		windowsInformationProtectionPolicies?: WindowsInformationProtectionPolicy[]
+
 	    /** The managed app registrations. */
-		        managedAppRegistrations?: ManagedAppRegistration[]
-	
+		managedAppRegistrations?: ManagedAppRegistration[]
+
 	    /** The managed app statuses. */
-		        managedAppStatuses?: ManagedAppStatus[]
-	
+		managedAppStatuses?: ManagedAppStatus[]
+
 	    /** The Managed eBook. */
-		        managedEBooks?: ManagedEBook[]
-	
+		managedEBooks?: ManagedEBook[]
+
 }
 
 export interface MobileApp extends Entity {
 
 	    /** The admin provided or imported title of the app. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The description of the app. */
-		        description?: string
-	
+		description?: string
+
 	    /** The publisher of the app. */
-		        publisher?: string
-	
+		publisher?: string
+
 	    /** The large icon, to be displayed in the app details and used for upload of the icon. */
-		        largeIcon?: MimeContent
-	
+		largeIcon?: MimeContent
+
 	    /** The date and time the app was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** The date and time the app was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The value indicating whether the app is marked as featured by the admin. */
-		        isFeatured: boolean
-	
+		isFeatured?: boolean
+
 	    /** The privacy statement Url. */
-		        privacyInformationUrl?: string
-	
+		privacyInformationUrl?: string
+
 	    /** The more information Url. */
-		        informationUrl?: string
-	
+		informationUrl?: string
+
 	    /** The owner of the app. */
-		        owner?: string
-	
+		owner?: string
+
 	    /** The developer of the app. */
-		        developer?: string
-	
+		developer?: string
+
 	    /** Notes for the app. */
-		        notes?: string
-	
+		notes?: string
+
 	    /** The publishing state for the app. The app cannot be assigned unless the app is published. Possible values are: notPublished, processing, published. */
-		        publishingState: MobileAppPublishingState
-	
+		publishingState?: MobileAppPublishingState
+
 	    /** The list of categories for this app. */
-		        categories?: MobileAppCategory[]
-	
+		categories?: MobileAppCategory[]
+
 	    /** The list of group assignments for this mobile app. */
-		        assignments?: MobileAppAssignment[]
-	
+		assignments?: MobileAppAssignment[]
+
 }
 
 export interface MobileAppCategory extends Entity {
 
 	    /** The name of the app category. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The date and time the mobileAppCategory was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 }
 
 export interface ManagedDeviceMobileAppConfiguration extends Entity {
 
 	    /** the associated app. */
-		        targetedMobileApps?: string[]
-	
+		targetedMobileApps?: string[]
+
 	    /** DateTime the object was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Admin provided description of the Device Configuration. */
-		        description?: string
-	
+		description?: string
+
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Admin provided name of the device configuration. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Version of the device configuration. */
-		        version: number
-	
+		version?: number
+
 	    /** The list of group assignemenets for app configration. */
-		        assignments?: ManagedDeviceMobileAppConfigurationAssignment[]
-	
+		assignments?: ManagedDeviceMobileAppConfigurationAssignment[]
+
 	    /** List of ManagedDeviceMobileAppConfigurationDeviceStatus. */
-		        deviceStatuses?: ManagedDeviceMobileAppConfigurationDeviceStatus[]
-	
+		deviceStatuses?: ManagedDeviceMobileAppConfigurationDeviceStatus[]
+
 	    /** List of ManagedDeviceMobileAppConfigurationUserStatus. */
-		        userStatuses?: ManagedDeviceMobileAppConfigurationUserStatus[]
-	
+		userStatuses?: ManagedDeviceMobileAppConfigurationUserStatus[]
+
 	    /** App configuration device status summary. */
-		        deviceStatusSummary?: ManagedDeviceMobileAppConfigurationDeviceSummary
-	
+		deviceStatusSummary?: ManagedDeviceMobileAppConfigurationDeviceSummary
+
 	    /** App configuration user status summary. */
-		        userStatusSummary?: ManagedDeviceMobileAppConfigurationUserSummary
-	
+		userStatusSummary?: ManagedDeviceMobileAppConfigurationUserSummary
+
 }
 
 export interface VppToken extends Entity {
 
 	    /** The organization associated with the Apple Volume Purchase Program Token */
-		        organizationName?: string
-	
+		organizationName?: string
+
 	    /** The type of volume purchase program which the given Apple Volume Purchase Program Token is associated with. Possible values are: business, education. Possible values are: business, education. */
-		        vppTokenAccountType: VppTokenAccountType
-	
+		vppTokenAccountType?: VppTokenAccountType
+
 	    /** The apple Id associated with the given Apple Volume Purchase Program Token. */
-		        appleId?: string
-	
+		appleId?: string
+
 	    /** The expiration date time of the Apple Volume Purchase Program Token. */
-		        expirationDateTime: string
-	
+		expirationDateTime?: string
+
 	    /** The last time when an application sync was done with the Apple volume purchase program service using the the Apple Volume Purchase Program Token. */
-		        lastSyncDateTime: string
-	
+		lastSyncDateTime?: string
+
 	    /** The Apple Volume Purchase Program Token string downloaded from the Apple Volume Purchase Program. */
-		        token?: string
-	
+		token?: string
+
 	    /** Last modification date time associated with the Apple Volume Purchase Program Token. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Current state of the Apple Volume Purchase Program Token. Possible values are: unknown, valid, expired, invalid. Possible values are: unknown, valid, expired, invalid. */
-		        state: VppTokenState
-	
+		state?: VppTokenState
+
 	    /** Current sync status of the last application sync which was triggered using the Apple Volume Purchase Program Token. Possible values are: none, inProgress, completed, failed. Possible values are: none, inProgress, completed, failed. */
-		        lastSyncStatus: VppTokenSyncStatus
-	
+		lastSyncStatus?: VppTokenSyncStatus
+
 	    /** Whether or not apps for the VPP token will be automatically updated. */
-		        automaticallyUpdateApps: boolean
-	
+		automaticallyUpdateApps?: boolean
+
 	    /** Whether or not apps for the VPP token will be automatically updated. */
-		        countryOrRegion?: string
-	
+		countryOrRegion?: string
+
 }
 
 export interface ManagedAppPolicy extends Entity {
 
 	    /** Policy display name. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** The policy's description. */
-		        description?: string
-	
+		description?: string
+
 	    /** The date and time the policy was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Last time the policy was modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface ManagedAppProtection extends ManagedAppPolicy {
 
 	    /** The period after which access is checked when the device is not connected to the internet. */
-		        periodOfflineBeforeAccessCheck: string
-	
+		periodOfflineBeforeAccessCheck?: string
+
 	    /** The period after which access is checked when the device is connected to the internet. */
-		        periodOnlineBeforeAccessCheck: string
-	
+		periodOnlineBeforeAccessCheck?: string
+
 	    /** Sources from which data is allowed to be transferred. Possible values are: allApps, managedApps, none. */
-		        allowedInboundDataTransferSources: ManagedAppDataTransferLevel
-	
+		allowedInboundDataTransferSources?: ManagedAppDataTransferLevel
+
 	    /** Destinations to which data is allowed to be transferred. Possible values are: allApps, managedApps, none. */
-		        allowedOutboundDataTransferDestinations: ManagedAppDataTransferLevel
-	
+		allowedOutboundDataTransferDestinations?: ManagedAppDataTransferLevel
+
 	    /** Indicates whether organizational credentials are required for app use. */
-		        organizationalCredentialsRequired: boolean
-	
+		organizationalCredentialsRequired?: boolean
+
 	    /** The level to which the clipboard may be shared between apps on the managed device. Possible values are: allApps, managedAppsWithPasteIn, managedApps, blocked. */
-		        allowedOutboundClipboardSharingLevel: ManagedAppClipboardSharingLevel
-	
+		allowedOutboundClipboardSharingLevel?: ManagedAppClipboardSharingLevel
+
 	    /** Indicates whether the backup of a managed app's data is blocked. */
-		        dataBackupBlocked: boolean
-	
+		dataBackupBlocked?: boolean
+
 	    /** Indicates whether device compliance is required. */
-		        deviceComplianceRequired: boolean
-	
+		deviceComplianceRequired?: boolean
+
 	    /** Indicates whether internet links should be opened in the managed browser app. */
-		        managedBrowserToOpenLinksRequired: boolean
-	
+		managedBrowserToOpenLinksRequired?: boolean
+
 	    /** Indicates whether users may use the "Save As" menu item to save a copy of protected files. */
-		        saveAsBlocked: boolean
-	
+		saveAsBlocked?: boolean
+
 	    /** The amount of time an app is allowed to remain disconnected from the internet before all managed data it is wiped. */
-		        periodOfflineBeforeWipeIsEnforced: string
-	
+		periodOfflineBeforeWipeIsEnforced?: string
+
 	    /** Indicates whether an app-level pin is required. */
-		        pinRequired: boolean
-	
+		pinRequired?: boolean
+
 	    /** Maximum number of incorrect pin retry attempts before the managed app is either blocked or wiped. */
-		        maximumPinRetries: number
-	
+		maximumPinRetries?: number
+
 	    /** Indicates whether simplePin is blocked. */
-		        simplePinBlocked: boolean
-	
+		simplePinBlocked?: boolean
+
 	    /** Minimum pin length required for an app-level pin if PinRequired is set to True */
-		        minimumPinLength: number
-	
+		minimumPinLength?: number
+
 	    /** Character set which may be used for an app-level pin if PinRequired is set to True. Possible values are: numeric, alphanumericAndSymbol. */
-		        pinCharacterSet: ManagedAppPinCharacterSet
-	
+		pinCharacterSet?: ManagedAppPinCharacterSet
+
 	    /** TimePeriod before the all-level pin must be reset if PinRequired is set to True. */
-		        periodBeforePinReset: string
-	
+		periodBeforePinReset?: string
+
 	    /** Data storage locations where a user may store managed data. */
-		        allowedDataStorageLocations: ManagedAppDataStorageLocation[]
-	
+		allowedDataStorageLocations?: ManagedAppDataStorageLocation[]
+
 	    /** Indicates whether contacts can be synced to the user's device. */
-		        contactSyncBlocked: boolean
-	
+		contactSyncBlocked?: boolean
+
 	    /** Indicates whether printing is allowed from managed apps. */
-		        printBlocked: boolean
-	
+		printBlocked?: boolean
+
 	    /** Indicates whether use of the fingerprint reader is allowed in place of a pin if PinRequired is set to True. */
-		        fingerprintBlocked: boolean
-	
+		fingerprintBlocked?: boolean
+
 	    /** Indicates whether use of the app pin is required if the device pin is set. */
-		        disableAppPinIfDevicePinIsSet: boolean
-	
+		disableAppPinIfDevicePinIsSet?: boolean
+
 	    /** Versions less than the specified version will block the managed app from accessing company data. */
-		        minimumRequiredOsVersion?: string
-	
+		minimumRequiredOsVersion?: string
+
 	    /** Versions less than the specified version will result in warning message on the managed app from accessing company data. */
-		        minimumWarningOsVersion?: string
-	
+		minimumWarningOsVersion?: string
+
 	    /** Versions less than the specified version will block the managed app from accessing company data. */
-		        minimumRequiredAppVersion?: string
-	
+		minimumRequiredAppVersion?: string
+
 	    /** Versions less than the specified version will result in warning message on the managed app. */
-		        minimumWarningAppVersion?: string
-	
+		minimumWarningAppVersion?: string
+
 }
 
 export interface TargetedManagedAppProtection extends ManagedAppProtection {
 
 	    /** Indicates if the policy is deployed to any inclusion groups or not. */
-		        isAssigned: boolean
-	
+		isAssigned?: boolean
+
 	    /** Navigation property to list of inclusion and exclusion groups to which the policy is deployed. */
-		        assignments?: TargetedManagedAppPolicyAssignment[]
-	
+		assignments?: TargetedManagedAppPolicyAssignment[]
+
 }
 
 export interface IosManagedAppProtection extends TargetedManagedAppProtection {
 
 	    /** Type of encryption which should be used for data in a managed app. Possible values are: useDeviceSettings, afterDeviceRestart, whenDeviceLockedExceptOpenFiles, whenDeviceLocked. */
-		        appDataEncryptionType: ManagedAppDataEncryptionType
-	
+		appDataEncryptionType?: ManagedAppDataEncryptionType
+
 	    /** Versions less than the specified version will block the managed app from accessing company data. */
-		        minimumRequiredSdkVersion?: string
-	
+		minimumRequiredSdkVersion?: string
+
 	    /** Count of apps to which the current policy is deployed. */
-		        deployedAppCount: number
-	
+		deployedAppCount?: number
+
 	    /** Indicates whether use of the FaceID is allowed in place of a pin if PinRequired is set to True. */
-		        faceIdBlocked: boolean
-	
+		faceIdBlocked?: boolean
+
 	    /** List of apps to which the policy is deployed. */
-		        apps?: ManagedMobileApp[]
-	
+		apps?: ManagedMobileApp[]
+
 	    /** Navigation property to deployment summary of the configuration. */
-		        deploymentSummary?: ManagedAppPolicyDeploymentSummary
-	
+		deploymentSummary?: ManagedAppPolicyDeploymentSummary
+
 }
 
 export interface AndroidManagedAppProtection extends TargetedManagedAppProtection {
 
 	    /** Indicates whether a managed user can take screen captures of managed apps */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** When this setting is enabled, app level encryption is disabled if device level encryption is enabled */
-		        disableAppEncryptionIfDeviceEncryptionIsEnabled: boolean
-	
+		disableAppEncryptionIfDeviceEncryptionIsEnabled?: boolean
+
 	    /** Indicates whether application data for managed apps should be encrypted */
-		        encryptAppData: boolean
-	
+		encryptAppData?: boolean
+
 	    /** Count of apps to which the current policy is deployed. */
-		        deployedAppCount: number
-	
+		deployedAppCount?: number
+
 	    /** Define the oldest required Android security patch level a user can have to gain secure access to the app. */
-		        minimumRequiredPatchVersion?: string
-	
+		minimumRequiredPatchVersion?: string
+
 	    /** Define the oldest recommended Android security patch level a user can have for secure access to the app. */
-		        minimumWarningPatchVersion?: string
-	
+		minimumWarningPatchVersion?: string
+
 	    /** List of apps to which the policy is deployed. */
-		        apps?: ManagedMobileApp[]
-	
+		apps?: ManagedMobileApp[]
+
 	    /** Navigation property to deployment summary of the configuration. */
-		        deploymentSummary?: ManagedAppPolicyDeploymentSummary
-	
+		deploymentSummary?: ManagedAppPolicyDeploymentSummary
+
 }
 
 export interface DefaultManagedAppProtection extends ManagedAppProtection {
 
 	    /** Type of encryption which should be used for data in a managed app. (iOS Only). Possible values are: useDeviceSettings, afterDeviceRestart, whenDeviceLockedExceptOpenFiles, whenDeviceLocked. */
-		        appDataEncryptionType: ManagedAppDataEncryptionType
-	
+		appDataEncryptionType?: ManagedAppDataEncryptionType
+
 	    /** Indicates whether screen capture is blocked. */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** Indicates whether managed-app data should be encrypted. (Android only) */
-		        encryptAppData: boolean
-	
+		encryptAppData?: boolean
+
 	    /** When this setting is enabled, app level encryption is disabled if device level encryption is enabled */
-		        disableAppEncryptionIfDeviceEncryptionIsEnabled: boolean
-	
+		disableAppEncryptionIfDeviceEncryptionIsEnabled?: boolean
+
 	    /** Versions less than the specified version will block the managed app from accessing company data. */
-		        minimumRequiredSdkVersion?: string
-	
+		minimumRequiredSdkVersion?: string
+
 	    /** A set of string key and string value pairs to be sent to the affected users, unalterned by this service */
-		        customSettings: KeyValuePair[]
-	
+		customSettings?: KeyValuePair[]
+
 	    /** Count of apps to which the current policy is deployed. */
-		        deployedAppCount: number
-	
+		deployedAppCount?: number
+
 	    /** Define the oldest required Android security patch level a user can have to gain secure access to the app. */
-		        minimumRequiredPatchVersion?: string
-	
+		minimumRequiredPatchVersion?: string
+
 	    /** Define the oldest recommended Android security patch level a user can have for secure access to the app. */
-		        minimumWarningPatchVersion?: string
-	
+		minimumWarningPatchVersion?: string
+
 	    /** Indicates whether use of the FaceID is allowed in place of a pin if PinRequired is set to True. */
-		        faceIdBlocked: boolean
-	
+		faceIdBlocked?: boolean
+
 	    /** List of apps to which the policy is deployed. */
-		        apps?: ManagedMobileApp[]
-	
+		apps?: ManagedMobileApp[]
+
 	    /** Navigation property to deployment summary of the configuration. */
-		        deploymentSummary?: ManagedAppPolicyDeploymentSummary
-	
+		deploymentSummary?: ManagedAppPolicyDeploymentSummary
+
 }
 
 export interface ManagedAppConfiguration extends ManagedAppPolicy {
 
 	    /** A set of string key and string value pairs to be sent to apps for users to whom the configuration is scoped, unalterned by this service */
-		        customSettings: KeyValuePair[]
-	
+		customSettings?: KeyValuePair[]
+
 }
 
 export interface TargetedManagedAppConfiguration extends ManagedAppConfiguration {
 
 	    /** Count of apps to which the current policy is deployed. */
-		        deployedAppCount: number
-	
+		deployedAppCount?: number
+
 	    /** Indicates if the policy is deployed to any inclusion groups or not. */
-		        isAssigned: boolean
-	
+		isAssigned?: boolean
+
 	    /** List of apps to which the policy is deployed. */
-		        apps?: ManagedMobileApp[]
-	
+		apps?: ManagedMobileApp[]
+
 	    /** Navigation property to deployment summary of the configuration. */
-		        deploymentSummary?: ManagedAppPolicyDeploymentSummary
-	
+		deploymentSummary?: ManagedAppPolicyDeploymentSummary
+
 	    /** Navigation property to list of inclusion and exclusion groups to which the policy is deployed. */
-		        assignments?: TargetedManagedAppPolicyAssignment[]
-	
+		assignments?: TargetedManagedAppPolicyAssignment[]
+
 }
 
 export interface WindowsInformationProtection extends ManagedAppPolicy {
 
 	    /** WIP enforcement level.See the Enum definition for supported values. Possible values are: noProtection, encryptAndAuditOnly, encryptAuditAndPrompt, encryptAuditAndBlock. */
-		        enforcementLevel: WindowsInformationProtectionEnforcementLevel
-	
+		enforcementLevel?: WindowsInformationProtectionEnforcementLevel
+
 	    /** Primary enterprise domain */
-		        enterpriseDomain?: string
-	
+		enterpriseDomain?: string
+
 	    /** List of enterprise domains to be protected */
-		        enterpriseProtectedDomainNames?: WindowsInformationProtectionResourceCollection[]
-	
+		enterpriseProtectedDomainNames?: WindowsInformationProtectionResourceCollection[]
+
 	    /** Specifies whether the protection under lock feature (also known as encrypt under pin) should be configured */
-		        protectionUnderLockConfigRequired: boolean
-	
+		protectionUnderLockConfigRequired?: boolean
+
 	    /** Specifies a recovery certificate that can be used for data recovery of encrypted files. This is the same as the data recovery agent(DRA) certificate for encrypting file system(EFS) */
-		        dataRecoveryCertificate?: WindowsInformationProtectionDataRecoveryCertificate
-	
+		dataRecoveryCertificate?: WindowsInformationProtectionDataRecoveryCertificate
+
 	    /** This policy controls whether to revoke the WIP keys when a device unenrolls from the management service. If set to 1 (Don't revoke keys), the keys will not be revoked and the user will continue to have access to protected files after unenrollment. If the keys are not revoked, there will be no revoked file cleanup subsequently. */
-		        revokeOnUnenrollDisabled: boolean
-	
+		revokeOnUnenrollDisabled?: boolean
+
 	    /** TemplateID GUID to use for RMS encryption. The RMS template allows the IT admin to configure the details about who has access to RMS-protected file and how long they have access */
-		        rightsManagementServicesTemplateId?: string
-	
+		rightsManagementServicesTemplateId?: string
+
 	    /** Specifies whether to allow Azure RMS encryption for WIP */
-		        azureRightsManagementServicesAllowed: boolean
-	
+		azureRightsManagementServicesAllowed?: boolean
+
 	    /** Determines whether overlays are added to icons for WIP protected files in Explorer and enterprise only app tiles in the Start menu. Starting in Windows 10, version 1703 this setting also configures the visibility of the WIP icon in the title bar of a WIP-protected app */
-		        iconsVisible: boolean
-	
+		iconsVisible?: boolean
+
 	    /** Protected applications can access enterprise data and the data handled by those applications are protected with encryption */
-		        protectedApps?: WindowsInformationProtectionApp[]
-	
+		protectedApps?: WindowsInformationProtectionApp[]
+
 	    /** Exempt applications can also access enterprise data, but the data handled by those applications are not protected. This is because some critical enterprise applications may have compatibility problems with encrypted data. */
-		        exemptApps?: WindowsInformationProtectionApp[]
-	
+		exemptApps?: WindowsInformationProtectionApp[]
+
 	    /** This is the list of domains that comprise the boundaries of the enterprise. Data from one of these domains that is sent to a device will be considered enterprise data and protected These locations will be considered a safe destination for enterprise data to be shared to */
-		        enterpriseNetworkDomainNames?: WindowsInformationProtectionResourceCollection[]
-	
+		enterpriseNetworkDomainNames?: WindowsInformationProtectionResourceCollection[]
+
 	    /** Contains a list of Enterprise resource domains hosted in the cloud that need to be protected. Connections to these resources are considered enterprise data. If a proxy is paired with a cloud resource, traffic to the cloud resource will be routed through the enterprise network via the denoted proxy server (on Port 80). A proxy server used for this purpose must also be configured using the EnterpriseInternalProxyServers policy */
-		        enterpriseProxiedDomains?: WindowsInformationProtectionProxiedDomainCollection[]
-	
+		enterpriseProxiedDomains?: WindowsInformationProtectionProxiedDomainCollection[]
+
 	    /** Sets the enterprise IP ranges that define the computers in the enterprise network. Data that comes from those computers will be considered part of the enterprise and protected. These locations will be considered a safe destination for enterprise data to be shared to */
-		        enterpriseIPRanges?: WindowsInformationProtectionIPRangeCollection[]
-	
+		enterpriseIPRanges?: WindowsInformationProtectionIPRangeCollection[]
+
 	    /** Boolean value that tells the client to accept the configured list and not to use heuristics to attempt to find other subnets. Default is false */
-		        enterpriseIPRangesAreAuthoritative: boolean
-	
+		enterpriseIPRangesAreAuthoritative?: boolean
+
 	    /** This is a list of proxy servers. Any server not on this list is considered non-enterprise */
-		        enterpriseProxyServers?: WindowsInformationProtectionResourceCollection[]
-	
+		enterpriseProxyServers?: WindowsInformationProtectionResourceCollection[]
+
 	    /** This is the comma-separated list of internal proxy servers. For example, "157.54.14.28, 157.54.11.118, 10.202.14.167, 157.53.14.163, 157.69.210.59". These proxies have been configured by the admin to connect to specific resources on the Internet. They are considered to be enterprise network locations. The proxies are only leveraged in configuring the EnterpriseProxiedDomains policy to force traffic to the matched domains through these proxies */
-		        enterpriseInternalProxyServers?: WindowsInformationProtectionResourceCollection[]
-	
+		enterpriseInternalProxyServers?: WindowsInformationProtectionResourceCollection[]
+
 	    /** Boolean value that tells the client to accept the configured list of proxies and not try to detect other work proxies. Default is false */
-		        enterpriseProxyServersAreAuthoritative: boolean
-	
+		enterpriseProxyServersAreAuthoritative?: boolean
+
 	    /** List of domain names that can used for work or personal resource */
-		        neutralDomainResources?: WindowsInformationProtectionResourceCollection[]
-	
+		neutralDomainResources?: WindowsInformationProtectionResourceCollection[]
+
 	    /** This switch is for the Windows Search Indexer, to allow or disallow indexing of items */
-		        indexingEncryptedStoresOrItemsBlocked: boolean
-	
+		indexingEncryptedStoresOrItemsBlocked?: boolean
+
 	    /** Specifies a list of file extensions, so that files with these extensions are encrypted when copying from an SMB share within the corporate boundary */
-		        smbAutoEncryptedFileExtensions?: WindowsInformationProtectionResourceCollection[]
-	
+		smbAutoEncryptedFileExtensions?: WindowsInformationProtectionResourceCollection[]
+
 	    /** Indicates if the policy is deployed to any inclusion groups or not. */
-		        isAssigned: boolean
-	
+		isAssigned?: boolean
+
 	    /** Another way to input protected apps through xml files */
-		        protectedAppLockerFiles?: WindowsInformationProtectionAppLockerFile[]
-	
+		protectedAppLockerFiles?: WindowsInformationProtectionAppLockerFile[]
+
 	    /** Another way to input exempt apps through xml files */
-		        exemptAppLockerFiles?: WindowsInformationProtectionAppLockerFile[]
-	
+		exemptAppLockerFiles?: WindowsInformationProtectionAppLockerFile[]
+
 	    /** Navigation property to list of security groups targeted for policy. */
-		        assignments?: TargetedManagedAppPolicyAssignment[]
-	
+		assignments?: TargetedManagedAppPolicyAssignment[]
+
 }
 
 export interface MdmWindowsInformationProtectionPolicy extends WindowsInformationProtection {
@@ -3946,138 +3999,138 @@ export interface MdmWindowsInformationProtectionPolicy extends WindowsInformatio
 export interface WindowsInformationProtectionPolicy extends WindowsInformationProtection {
 
 	    /** New property in RS2, pending documentation */
-		        revokeOnMdmHandoffDisabled: boolean
-	
+		revokeOnMdmHandoffDisabled?: boolean
+
 	    /** Enrollment url for the MDM */
-		        mdmEnrollmentUrl?: string
-	
+		mdmEnrollmentUrl?: string
+
 	    /** Boolean value that sets Windows Hello for Business as a method for signing into Windows. */
-		        windowsHelloForBusinessBlocked: boolean
-	
+		windowsHelloForBusinessBlocked?: boolean
+
 	    /** Integer value that sets the minimum number of characters required for the PIN. Default value is 4. The lowest number you can configure for this policy setting is 4. The largest number you can configure must be less than the number configured in the Maximum PIN length policy setting or the number 127, whichever is the lowest. */
-		        pinMinimumLength: number
-	
+		pinMinimumLength?: number
+
 	    /** Integer value that configures the use of uppercase letters in the Windows Hello for Business PIN. Default is NotAllow. Possible values are: notAllow, requireAtLeastOne, allow. */
-		        pinUppercaseLetters: WindowsInformationProtectionPinCharacterRequirements
-	
+		pinUppercaseLetters?: WindowsInformationProtectionPinCharacterRequirements
+
 	    /** Integer value that configures the use of lowercase letters in the Windows Hello for Business PIN. Default is NotAllow. Possible values are: notAllow, requireAtLeastOne, allow. */
-		        pinLowercaseLetters: WindowsInformationProtectionPinCharacterRequirements
-	
+		pinLowercaseLetters?: WindowsInformationProtectionPinCharacterRequirements
+
 	    /** Integer value that configures the use of special characters in the Windows Hello for Business PIN. Valid special characters for Windows Hello for Business PIN gestures include: ! " # $ % & ' ( )  + , - . / : ; < = > ? @ [ \ ] ^  ` { */
-		        pinSpecialCharacters: WindowsInformationProtectionPinCharacterRequirements
-	
+		pinSpecialCharacters?: WindowsInformationProtectionPinCharacterRequirements
+
 	    /** Integer value specifies the period of time (in days) that a PIN can be used before the system requires the user to change it. The largest number you can configure for this policy setting is 730. The lowest number you can configure for this policy setting is 0. If this policy is set to 0, then the user's PIN will never expire. This node was added in Windows 10, version 1511. Default is 0. */
-		        pinExpirationDays: number
-	
+		pinExpirationDays?: number
+
 	    /** Integer value that specifies the number of past PINs that can be associated to a user account that can't be reused. The largest number you can configure for this policy setting is 50. The lowest number you can configure for this policy setting is 0. If this policy is set to 0, then storage of previous PINs is not required. This node was added in Windows 10, version 1511. Default is 0. */
-		        numberOfPastPinsRemembered: number
-	
+		numberOfPastPinsRemembered?: number
+
 	    /** The number of authentication failures allowed before the device will be wiped. A value of 0 disables device wipe functionality. Range is an integer X where 4 <= X <= 16 for desktop and 0 <= X <= 999 for mobile devices. */
-		        passwordMaximumAttemptCount: number
-	
+		passwordMaximumAttemptCount?: number
+
 	    /** Specifies the maximum amount of time (in minutes) allowed after the device is idle that will cause the device to become PIN or password locked.   Range is an integer X where 0 <= X <= 999. */
-		        minutesOfInactivityBeforeDeviceLock: number
-	
+		minutesOfInactivityBeforeDeviceLock?: number
+
 	    /** Offline interval before app data is wiped (days) */
-		        daysWithoutContactBeforeUnenroll: number
-	
+		daysWithoutContactBeforeUnenroll?: number
+
 }
 
 export interface ManagedAppStatus extends Entity {
 
 	    /** Friendly name of the status report. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface ManagedEBook extends Entity {
 
 	    /** Name of the eBook. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Description. */
-		        description?: string
-	
+		description?: string
+
 	    /** Publisher. */
-		        publisher?: string
-	
+		publisher?: string
+
 	    /** The date and time when the eBook was published. */
-		        publishedDateTime: string
-	
+		publishedDateTime?: string
+
 	    /** Book cover. */
-		        largeCover?: MimeContent
-	
+		largeCover?: MimeContent
+
 	    /** The date and time when the eBook file was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** The date and time when the eBook was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The more information Url. */
-		        informationUrl?: string
-	
+		informationUrl?: string
+
 	    /** The privacy statement Url. */
-		        privacyInformationUrl?: string
-	
+		privacyInformationUrl?: string
+
 	    /** The list of assignments for this eBook. */
-		        assignments?: ManagedEBookAssignment[]
-	
+		assignments?: ManagedEBookAssignment[]
+
 	    /** Mobile App Install Summary. */
-		        installSummary?: EBookInstallSummary
-	
+		installSummary?: EBookInstallSummary
+
 	    /** The list of installation states for this eBook. */
-		        deviceStates?: DeviceInstallState[]
-	
+		deviceStates?: DeviceInstallState[]
+
 	    /** The list of installation states for this eBook. */
-		        userStateSummary?: UserInstallStateSummary[]
-	
+		userStateSummary?: UserInstallStateSummary[]
+
 }
 
 export interface MobileAppAssignment extends Entity {
 
 	    /** The install intent defined by the admin. Possible values are: available, required, uninstall, availableWithoutEnrollment. */
-		        intent: InstallIntent
-	
+		intent?: InstallIntent
+
 	    /** The target group assignment defined by the admin. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 	    /** The settings for target assignment defined by the admin. */
-		        settings?: MobileAppAssignmentSettings
-	
+		settings?: MobileAppAssignmentSettings
+
 }
 
 export interface MobileAppContentFile extends Entity {
 
 	    /** The Azure Storage URI. */
-		        azureStorageUri?: string
-	
+		azureStorageUri?: string
+
 	    /** A value indicating whether the file is committed. */
-		        isCommitted: boolean
-	
+		isCommitted?: boolean
+
 	    /** The time the file was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** the file name. */
-		        name?: string
-	
+		name?: string
+
 	    /** The size of the file prior to encryption. */
-		        size: number
-	
+		size?: number
+
 	    /** The size of the file after encryption. */
-		        sizeEncrypted: number
-	
+		sizeEncrypted?: number
+
 	    /** The time the Azure storage Uri expires. */
-		        azureStorageUriExpirationDateTime?: string
-	
+		azureStorageUriExpirationDateTime?: string
+
 	    /** The manifest information. */
-		        manifest?: number
-	
+		manifest?: number
+
 	    /** The state of the current upload request. Possible values are: success, transientError, error, unknown, azureStorageUriRequestSuccess, azureStorageUriRequestPending, azureStorageUriRequestFailed, azureStorageUriRequestTimedOut, azureStorageUriRenewalSuccess, azureStorageUriRenewalPending, azureStorageUriRenewalFailed, azureStorageUriRenewalTimedOut, commitFileSuccess, commitFilePending, commitFileFailed, commitFileTimedOut. */
-		        uploadState: MobileAppContentFileUploadState
-	
+		uploadState?: MobileAppContentFileUploadState
+
 }
 
 export interface MacOSOfficeSuiteApp extends MobileApp {
@@ -4087,1552 +4140,1630 @@ export interface MacOSOfficeSuiteApp extends MobileApp {
 export interface ManagedApp extends MobileApp {
 
 	    /** The Application's availability. Possible values are: global, lineOfBusiness. */
-		        appAvailability: ManagedAppAvailability
-	
+		appAvailability?: ManagedAppAvailability
+
 	    /** The Application's version. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface ManagedAndroidStoreApp extends ManagedApp {
 
 	    /** The app's package ID. */
-		        packageId?: string
-	
+		packageId?: string
+
 	    /** The Android AppStoreUrl. */
-		        appStoreUrl: string
-	
+		appStoreUrl?: string
+
 	    /** The value for the minimum supported operating system. */
-		        minimumSupportedOperatingSystem: AndroidMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
+
 }
 
 export interface ManagedIOSStoreApp extends ManagedApp {
 
 	    /** The app's Bundle ID. */
-		        bundleId?: string
-	
+		bundleId?: string
+
 	    /** The Apple AppStoreUrl. */
-		        appStoreUrl: string
-	
+		appStoreUrl?: string
+
 	    /** The iOS architecture for which this app can run on. */
-		        applicableDeviceType: IosDeviceType
-	
+		applicableDeviceType?: IosDeviceType
+
 	    /** The value for the minimum supported operating system. */
-		        minimumSupportedOperatingSystem: IosMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
+
 }
 
 export interface ManagedMobileLobApp extends ManagedApp {
 
 	    /** The internal committed content version. */
-		        committedContentVersion?: string
-	
+		committedContentVersion?: string
+
 	    /** The name of the main Lob application file. */
-		        fileName?: string
-	
+		fileName?: string
+
 	    /** The total size, including all uploaded files. */
-		        size: number
-	
+		size?: number
+
 	    /** The list of content versions for this app. */
-		        contentVersions?: MobileAppContent[]
-	
+		contentVersions?: MobileAppContent[]
+
 }
 
 export interface MobileAppContent extends Entity {
 
 	    /** The list of files for this app content version. */
-		        files?: MobileAppContentFile[]
-	
+		files?: MobileAppContentFile[]
+
 }
 
 export interface ManagedAndroidLobApp extends ManagedMobileLobApp {
 
 	    /** The package identifier. */
-		        packageId?: string
-	
+		packageId?: string
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
+
 	    /** The version name of managed Android Line of Business (LoB) app. */
-		        versionName?: string
-	
+		versionName?: string
+
 	    /** The version code of managed Android Line of Business (LoB) app. */
-		        versionCode?: string
-	
+		versionCode?: string
+
 }
 
 export interface ManagedIOSLobApp extends ManagedMobileLobApp {
 
 	    /** The Identity Name. */
-		        bundleId?: string
-	
+		bundleId?: string
+
 	    /** The iOS architecture for which this app can run on. */
-		        applicableDeviceType: IosDeviceType
-	
+		applicableDeviceType?: IosDeviceType
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
+
 	    /** The expiration time. */
-		        expirationDateTime?: string
-	
+		expirationDateTime?: string
+
 	    /** The version number of managed iOS Line of Business (LoB) app. */
-		        versionNumber?: string
-	
+		versionNumber?: string
+
 	    /** The build number of managed iOS Line of Business (LoB) app. */
-		        buildNumber?: string
-	
+		buildNumber?: string
+
 }
 
 export interface MobileLobApp extends MobileApp {
 
 	    /** The internal committed content version. */
-		        committedContentVersion?: string
-	
+		committedContentVersion?: string
+
 	    /** The name of the main Lob application file. */
-		        fileName?: string
-	
+		fileName?: string
+
 	    /** The total size, including all uploaded files. */
-		        size: number
-	
+		size?: number
+
 	    /** The list of content versions for this app. */
-		        contentVersions?: MobileAppContent[]
-	
+		contentVersions?: MobileAppContent[]
+
 }
 
 export interface WindowsMobileMSI extends MobileLobApp {
 
 	    /** The command line. */
-		        commandLine?: string
-	
+		commandLine?: string
+
 	    /** The product code. */
-		        productCode?: string
-	
+		productCode?: string
+
 	    /** The product version of Windows Mobile MSI Line of Business (LoB) app. */
-		        productVersion?: string
-	
+		productVersion?: string
+
 	    /** A boolean to control whether the app's version will be used to detect the app after it is installed on a device. Set this to true for Windows Mobile MSI Line of Business (LoB) apps that use a self update feature. */
-		        ignoreVersionDetection: boolean
-	
+		ignoreVersionDetection?: boolean
+
 }
 
 export interface WindowsUniversalAppX extends MobileLobApp {
 
 	    /** The Windows architecture(s) for which this app can run on. Possible values are: none, x86, x64, arm, neutral. */
-		        applicableArchitectures: WindowsArchitecture
-	
+		applicableArchitectures?: WindowsArchitecture
+
 	    /** The Windows device type(s) for which this app can run on. Possible values are: none, desktop, mobile, holographic, team. */
-		        applicableDeviceTypes: WindowsDeviceType
-	
+		applicableDeviceTypes?: WindowsDeviceType
+
 	    /** The Identity Name. */
-		        identityName?: string
-	
+		identityName?: string
+
 	    /** The Identity Publisher Hash. */
-		        identityPublisherHash: string
-	
+		identityPublisherHash?: string
+
 	    /** The Identity Resource Identifier. */
-		        identityResourceIdentifier?: string
-	
+		identityResourceIdentifier?: string
+
 	    /** Whether or not the app is a bundle. */
-		        isBundle: boolean
-	
+		isBundle?: boolean
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem: WindowsMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: WindowsMinimumOperatingSystem
+
 	    /** The identity version. */
-		        identityVersion?: string
-	
+		identityVersion?: string
+
 }
 
 export interface AndroidLobApp extends MobileLobApp {
 
 	    /** The package identifier. */
-		        packageId?: string
-	
+		packageId?: string
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
+
 	    /** The version name of Android Line of Business (LoB) app. */
-		        versionName?: string
-	
+		versionName?: string
+
 	    /** The version code of Android Line of Business (LoB) app. */
-		        versionCode?: string
-	
+		versionCode?: string
+
 }
 
 export interface IosLobApp extends MobileLobApp {
 
 	    /** The Identity Name. */
-		        bundleId?: string
-	
+		bundleId?: string
+
 	    /** The iOS architecture for which this app can run on. */
-		        applicableDeviceType: IosDeviceType
-	
+		applicableDeviceType?: IosDeviceType
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
+
 	    /** The expiration time. */
-		        expirationDateTime?: string
-	
+		expirationDateTime?: string
+
 	    /** The version number of iOS Line of Business (LoB) app. */
-		        versionNumber?: string
-	
+		versionNumber?: string
+
 	    /** The build number of iOS Line of Business (LoB) app. */
-		        buildNumber?: string
-	
+		buildNumber?: string
+
 }
 
 export interface MicrosoftStoreForBusinessApp extends MobileApp {
 
 	    /** The number of Microsoft Store for Business licenses in use. */
-		        usedLicenseCount: number
-	
+		usedLicenseCount?: number
+
 	    /** The total number of Microsoft Store for Business licenses. */
-		        totalLicenseCount: number
-	
+		totalLicenseCount?: number
+
 	    /** The app product key */
-		        productKey?: string
-	
+		productKey?: string
+
 	    /** The app license type. Possible values are: offline, online. */
-		        licenseType: MicrosoftStoreForBusinessLicenseType
-	
+		licenseType?: MicrosoftStoreForBusinessLicenseType
+
 	    /** The app package identifier */
-		        packageIdentityName?: string
-	
+		packageIdentityName?: string
+
 }
 
 export interface WebApp extends MobileApp {
 
 	    /** The web app URL. */
-		        appUrl?: string
-	
+		appUrl?: string
+
 	    /** Whether or not to use managed browser. This property is only applicable for Android and IOS. */
-		        useManagedBrowser: boolean
-	
+		useManagedBrowser?: boolean
+
 }
 
 export interface AndroidStoreApp extends MobileApp {
 
 	    /** The package identifier. */
-		        packageId?: string
-	
+		packageId?: string
+
 	    /** The Android app store URL. */
-		        appStoreUrl?: string
-	
+		appStoreUrl?: string
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: AndroidMinimumOperatingSystem
+
 }
 
 export interface IosVppApp extends MobileApp {
 
 	    /** The number of VPP licenses in use. */
-		        usedLicenseCount: number
-	
+		usedLicenseCount?: number
+
 	    /** The total number of VPP licenses. */
-		        totalLicenseCount: number
-	
+		totalLicenseCount?: number
+
 	    /** The VPP application release date and time. */
-		        releaseDateTime?: string
-	
+		releaseDateTime?: string
+
 	    /** The store URL. */
-		        appStoreUrl?: string
-	
+		appStoreUrl?: string
+
 	    /** The supported License Type. */
-		        licensingType?: VppLicensingType
-	
+		licensingType?: VppLicensingType
+
 	    /** The applicable iOS Device Type. */
-		        applicableDeviceType?: IosDeviceType
-	
+		applicableDeviceType?: IosDeviceType
+
 	    /** The organization associated with the Apple Volume Purchase Program Token */
-		        vppTokenOrganizationName?: string
-	
+		vppTokenOrganizationName?: string
+
 	    /** The type of volume purchase program which the given Apple Volume Purchase Program Token is associated with. Possible values are: business, education. Possible values are: business, education. */
-		        vppTokenAccountType: VppTokenAccountType
-	
+		vppTokenAccountType?: VppTokenAccountType
+
 	    /** The Apple Id associated with the given Apple Volume Purchase Program Token. */
-		        vppTokenAppleId?: string
-	
+		vppTokenAppleId?: string
+
 	    /** The Identity Name. */
-		        bundleId?: string
-	
+		bundleId?: string
+
 }
 
 export interface IosStoreApp extends MobileApp {
 
 	    /** The Identity Name. */
-		        bundleId?: string
-	
+		bundleId?: string
+
 	    /** The Apple App Store URL */
-		        appStoreUrl?: string
-	
+		appStoreUrl?: string
+
 	    /** The iOS architecture for which this app can run on. */
-		        applicableDeviceType: IosDeviceType
-	
+		applicableDeviceType?: IosDeviceType
+
 	    /** The value for the minimum applicable operating system. */
-		        minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
-	
+		minimumSupportedOperatingSystem?: IosMinimumOperatingSystem
+
 }
 
 export interface ManagedDeviceMobileAppConfigurationDeviceStatus extends Entity {
 
 	    /** Device name of the DevicePolicyStatus. */
-		        deviceDisplayName?: string
-	
+		deviceDisplayName?: string
+
 	    /** The User Name that is being reported */
-		        userName?: string
-	
+		userName?: string
+
 	    /** The device model that is being reported */
-		        deviceModel?: string
-	
+		deviceModel?: string
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface ManagedDeviceMobileAppConfigurationUserStatus extends Entity {
 
 	    /** User name of the DevicePolicyStatus. */
-		        userDisplayName?: string
-	
+		userDisplayName?: string
+
 	    /** Devices count for that user. */
-		        devicesCount: number
-	
+		devicesCount?: number
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface ManagedDeviceMobileAppConfigurationAssignment extends Entity {
 
 	    /** Assignment target that the T&C policy is assigned to. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface ManagedDeviceMobileAppConfigurationDeviceSummary extends Entity {
 
 	    /** Number of pending devices */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded devices */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error devices */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed devices */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface ManagedDeviceMobileAppConfigurationUserSummary extends Entity {
 
 	    /** Number of pending Users */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded Users */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error Users */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed Users */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface IosMobileAppConfiguration extends ManagedDeviceMobileAppConfiguration {
 
 	    /** mdm app configuration Base64 binary. */
-		        encodedSettingXml?: number
-	
+		encodedSettingXml?: number
+
 	    /** app configuration setting items. */
-		        settings?: AppConfigurationSettingItem[]
-	
+		settings?: AppConfigurationSettingItem[]
+
 }
 
 export interface DeviceManagement extends Entity {
 
 	    /** Tenant mobile device management subscription state. Possible values are: pending, active, warning, disabled, deleted, blocked, lockedOut. */
-		        subscriptionState: DeviceManagementSubscriptionState
-	
-		        settings?: DeviceManagementSettings
-	
-		        intuneBrand?: IntuneBrand
-	
-		        termsAndConditions?: TermsAndConditions[]
-	
-		        applePushNotificationCertificate?: ApplePushNotificationCertificate
-	
-		        managedDeviceOverview?: ManagedDeviceOverview
-	
-		        detectedApps?: DetectedApp[]
-	
-		        managedDevices?: ManagedDevice[]
-	
-		        deviceConfigurations?: DeviceConfiguration[]
-	
-		        deviceCompliancePolicies?: DeviceCompliancePolicy[]
-	
-		        softwareUpdateStatusSummary?: SoftwareUpdateStatusSummary
-	
-		        deviceCompliancePolicyDeviceStateSummary?: DeviceCompliancePolicyDeviceStateSummary
-	
-		        deviceCompliancePolicySettingStateSummaries?: DeviceCompliancePolicySettingStateSummary[]
-	
-		        deviceConfigurationDeviceStateSummaries?: DeviceConfigurationDeviceStateSummary
-	
-		        iosUpdateStatuses?: IosUpdateDeviceStatus[]
-	
-		        deviceCategories?: DeviceCategory[]
-	
-		        exchangeConnectors?: DeviceManagementExchangeConnector[]
-	
-		        deviceEnrollmentConfigurations?: DeviceEnrollmentConfiguration[]
-	
-		        conditionalAccessSettings?: OnPremisesConditionalAccessSettings
-	
-		        mobileThreatDefenseConnectors?: MobileThreatDefenseConnector[]
-	
-		        deviceManagementPartners?: DeviceManagementPartner[]
-	
-		        notificationMessageTemplates?: NotificationMessageTemplate[]
-	
-		        roleDefinitions?: RoleDefinition[]
-	
-		        roleAssignments?: DeviceAndAppManagementRoleAssignment[]
-	
-		        resourceOperations?: ResourceOperation[]
-	
-		        telecomExpenseManagementPartners?: TelecomExpenseManagementPartner[]
-	
-		        remoteAssistancePartners?: RemoteAssistancePartner[]
-	
-		        windowsInformationProtectionAppLearningSummaries?: WindowsInformationProtectionAppLearningSummary[]
-	
-		        windowsInformationProtectionNetworkLearningSummaries?: WindowsInformationProtectionNetworkLearningSummary[]
-	
-		        troubleshootingEvents?: DeviceManagementTroubleshootingEvent[]
-	
+		subscriptionState?: DeviceManagementSubscriptionState
+
+		settings?: DeviceManagementSettings
+
+		intuneBrand?: IntuneBrand
+
+		termsAndConditions?: TermsAndConditions[]
+
+		applePushNotificationCertificate?: ApplePushNotificationCertificate
+
+		managedDeviceOverview?: ManagedDeviceOverview
+
+		detectedApps?: DetectedApp[]
+
+		managedDevices?: ManagedDevice[]
+
+		deviceConfigurations?: DeviceConfiguration[]
+
+		deviceCompliancePolicies?: DeviceCompliancePolicy[]
+
+		softwareUpdateStatusSummary?: SoftwareUpdateStatusSummary
+
+		deviceCompliancePolicyDeviceStateSummary?: DeviceCompliancePolicyDeviceStateSummary
+
+		deviceCompliancePolicySettingStateSummaries?: DeviceCompliancePolicySettingStateSummary[]
+
+		deviceConfigurationDeviceStateSummaries?: DeviceConfigurationDeviceStateSummary
+
+		iosUpdateStatuses?: IosUpdateDeviceStatus[]
+
+		deviceCategories?: DeviceCategory[]
+
+		exchangeConnectors?: DeviceManagementExchangeConnector[]
+
+		deviceEnrollmentConfigurations?: DeviceEnrollmentConfiguration[]
+
+		conditionalAccessSettings?: OnPremisesConditionalAccessSettings
+
+		mobileThreatDefenseConnectors?: MobileThreatDefenseConnector[]
+
+		deviceManagementPartners?: DeviceManagementPartner[]
+
+		notificationMessageTemplates?: NotificationMessageTemplate[]
+
+		roleDefinitions?: RoleDefinition[]
+
+		roleAssignments?: DeviceAndAppManagementRoleAssignment[]
+
+		resourceOperations?: ResourceOperation[]
+
+		telecomExpenseManagementPartners?: TelecomExpenseManagementPartner[]
+
+		remoteAssistancePartners?: RemoteAssistancePartner[]
+
+		windowsInformationProtectionAppLearningSummaries?: WindowsInformationProtectionAppLearningSummary[]
+
+		windowsInformationProtectionNetworkLearningSummaries?: WindowsInformationProtectionNetworkLearningSummary[]
+
+		troubleshootingEvents?: DeviceManagementTroubleshootingEvent[]
+
 }
 
 export interface TermsAndConditions extends Entity {
 
 	    /** DateTime the object was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Administrator-supplied name for the T&C policy. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Administrator-supplied description of the T&C policy. */
-		        description?: string
-	
+		description?: string
+
 	    /** Administrator-supplied title of the terms and conditions. This is shown to the user on prompts to accept the T&C policy. */
-		        title?: string
-	
+		title?: string
+
 	    /** Administrator-supplied body text of the terms and conditions, typically the terms themselves. This is shown to the user on prompts to accept the T&C policy. */
-		        bodyText?: string
-	
+		bodyText?: string
+
 	    /** Administrator-supplied explanation of the terms and conditions, typically describing what it means to accept the terms and conditions set out in the T&C policy. This is shown to the user on prompts to accept the T&C policy. */
-		        acceptanceStatement?: string
-	
+		acceptanceStatement?: string
+
 	    /** Integer indicating the current version of the terms. Incremented when an administrator makes a change to the terms and wishes to require users to re-accept the modified T&C policy. */
-		        version: number
-	
+		version?: number
+
 	    /** The list of assignments for this T&C policy. */
-		        assignments?: TermsAndConditionsAssignment[]
-	
+		assignments?: TermsAndConditionsAssignment[]
+
 	    /** The list of acceptance statuses for this T&C policy. */
-		        acceptanceStatuses?: TermsAndConditionsAcceptanceStatus[]
-	
+		acceptanceStatuses?: TermsAndConditionsAcceptanceStatus[]
+
 }
 
 export interface ApplePushNotificationCertificate extends Entity {
 
 	    /** Apple Id of the account used to create the MDM push certificate. */
-		        appleIdentifier?: string
-	
+		appleIdentifier?: string
+
 	    /** Topic Id. */
-		        topicIdentifier?: string
-	
+		topicIdentifier?: string
+
 	    /** Last modified date and time for Apple push notification certificate. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The expiration date and time for Apple push notification certificate. */
-		        expirationDateTime: string
-	
+		expirationDateTime?: string
+
 	    /** Not yet documented */
-		        certificate?: string
-	
+		certificate?: string
+
 }
 
 export interface ManagedDeviceOverview extends Entity {
 
 	    /** Total enrolled device count. Does not include PC devices managed via Intune PC Agent */
-		        enrolledDeviceCount: number
-	
+		enrolledDeviceCount?: number
+
 	    /** The number of devices enrolled in MDM */
-		        mdmEnrolledCount: number
-	
+		mdmEnrolledCount?: number
+
 	    /** The number of devices enrolled in both MDM and EAS */
-		        dualEnrolledDeviceCount: number
-	
+		dualEnrolledDeviceCount?: number
+
 	    /** Device operating system summary. */
-		        deviceOperatingSystemSummary?: DeviceOperatingSystemSummary
-	
+		deviceOperatingSystemSummary?: DeviceOperatingSystemSummary
+
 	    /** Distribution of Exchange Access State in Intune */
-		        deviceExchangeAccessStateSummary?: DeviceExchangeAccessStateSummary
-	
+		deviceExchangeAccessStateSummary?: DeviceExchangeAccessStateSummary
+
 }
 
 export interface DetectedApp extends Entity {
 
 	    /** Name of the discovered application. Read-only */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Version of the discovered application. Read-only */
-		        version?: string
-	
+		version?: string
+
 	    /** Discovered application size in bytes. Read-only */
-		        sizeInByte: number
-	
+		sizeInByte?: number
+
 	    /** The number of devices that have installed this application */
-		        deviceCount: number
-	
+		deviceCount?: number
+
 	    /** The devices that have the discovered application installed */
-		        managedDevices?: ManagedDevice[]
-	
+		managedDevices?: ManagedDevice[]
+
 }
 
 export interface DeviceConfiguration extends Entity {
 
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** DateTime the object was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Admin provided description of the Device Configuration. */
-		        description?: string
-	
+		description?: string
+
 	    /** Admin provided name of the device configuration. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Version of the device configuration. */
-		        version: number
-	
+		version?: number
+
 	    /** The list of assignments for the device configuration profile. */
-		        assignments?: DeviceConfigurationAssignment[]
-	
+		assignments?: DeviceConfigurationAssignment[]
+
 	    /** Device configuration installation status by device. */
-		        deviceStatuses?: DeviceConfigurationDeviceStatus[]
-	
+		deviceStatuses?: DeviceConfigurationDeviceStatus[]
+
 	    /** Device configuration installation stauts by user. */
-		        userStatuses?: DeviceConfigurationUserStatus[]
-	
+		userStatuses?: DeviceConfigurationUserStatus[]
+
 	    /** Device Configuration devices status overview */
-		        deviceStatusOverview?: DeviceConfigurationDeviceOverview
-	
+		deviceStatusOverview?: DeviceConfigurationDeviceOverview
+
 	    /** Device Configuration users status overview */
-		        userStatusOverview?: DeviceConfigurationUserOverview
-	
+		userStatusOverview?: DeviceConfigurationUserOverview
+
 	    /** Device Configuration Setting State Device Summary */
-		        deviceSettingStateSummaries?: SettingStateDeviceSummary[]
-	
+		deviceSettingStateSummaries?: SettingStateDeviceSummary[]
+
 }
 
 export interface DeviceCompliancePolicy extends Entity {
 
 	    /** DateTime the object was created. */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Admin provided description of the Device Configuration. */
-		        description?: string
-	
+		description?: string
+
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Admin provided name of the device configuration. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** Version of the device configuration. */
-		        version: number
-	
+		version?: number
+
 	    /** The list of scheduled action for this rule */
-		        scheduledActionsForRule?: DeviceComplianceScheduledActionForRule[]
-	
+		scheduledActionsForRule?: DeviceComplianceScheduledActionForRule[]
+
 	    /** List of DeviceComplianceDeviceStatus. */
-		        deviceStatuses?: DeviceComplianceDeviceStatus[]
-	
+		deviceStatuses?: DeviceComplianceDeviceStatus[]
+
 	    /** List of DeviceComplianceUserStatus. */
-		        userStatuses?: DeviceComplianceUserStatus[]
-	
+		userStatuses?: DeviceComplianceUserStatus[]
+
 	    /** Device compliance devices status overview */
-		        deviceStatusOverview?: DeviceComplianceDeviceOverview
-	
+		deviceStatusOverview?: DeviceComplianceDeviceOverview
+
 	    /** Device compliance users status overview */
-		        userStatusOverview?: DeviceComplianceUserOverview
-	
+		userStatusOverview?: DeviceComplianceUserOverview
+
 	    /** Compliance Setting State Device Summary */
-		        deviceSettingStateSummaries?: SettingStateDeviceSummary[]
-	
+		deviceSettingStateSummaries?: SettingStateDeviceSummary[]
+
 	    /** The collection of assignments for this compliance policy. */
-		        assignments?: DeviceCompliancePolicyAssignment[]
-	
+		assignments?: DeviceCompliancePolicyAssignment[]
+
 }
 
 export interface SoftwareUpdateStatusSummary extends Entity {
 
 	    /** The name of the policy. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Number of compliant devices. */
-		        compliantDeviceCount: number
-	
+		compliantDeviceCount?: number
+
 	    /** Number of non compliant devices. */
-		        nonCompliantDeviceCount: number
-	
+		nonCompliantDeviceCount?: number
+
 	    /** Number of remediated devices. */
-		        remediatedDeviceCount: number
-	
+		remediatedDeviceCount?: number
+
 	    /** Number of devices had error. */
-		        errorDeviceCount: number
-	
+		errorDeviceCount?: number
+
 	    /** Number of unknown devices. */
-		        unknownDeviceCount: number
-	
+		unknownDeviceCount?: number
+
 	    /** Number of conflict devices. */
-		        conflictDeviceCount: number
-	
+		conflictDeviceCount?: number
+
 	    /** Number of not applicable devices. */
-		        notApplicableDeviceCount: number
-	
+		notApplicableDeviceCount?: number
+
 	    /** Number of compliant users. */
-		        compliantUserCount: number
-	
+		compliantUserCount?: number
+
 	    /** Number of non compliant users. */
-		        nonCompliantUserCount: number
-	
+		nonCompliantUserCount?: number
+
 	    /** Number of remediated users. */
-		        remediatedUserCount: number
-	
+		remediatedUserCount?: number
+
 	    /** Number of users had error. */
-		        errorUserCount: number
-	
+		errorUserCount?: number
+
 	    /** Number of unknown users. */
-		        unknownUserCount: number
-	
+		unknownUserCount?: number
+
 	    /** Number of conflict users. */
-		        conflictUserCount: number
-	
+		conflictUserCount?: number
+
 	    /** Number of not applicable users. */
-		        notApplicableUserCount: number
-	
+		notApplicableUserCount?: number
+
 }
 
 export interface DeviceCompliancePolicyDeviceStateSummary extends Entity {
 
 	    /** Number of devices that are in grace period */
-		        inGracePeriodCount: number
-	
+		inGracePeriodCount?: number
+
 	    /** Number of devices that have compliance managed by System Center Configuration Manager */
-		        configManagerCount: number
-	
+		configManagerCount?: number
+
 	    /** Number of unknown devices */
-		        unknownDeviceCount: number
-	
+		unknownDeviceCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableDeviceCount: number
-	
+		notApplicableDeviceCount?: number
+
 	    /** Number of compliant devices */
-		        compliantDeviceCount: number
-	
+		compliantDeviceCount?: number
+
 	    /** Number of remediated devices */
-		        remediatedDeviceCount: number
-	
+		remediatedDeviceCount?: number
+
 	    /** Number of NonCompliant devices */
-		        nonCompliantDeviceCount: number
-	
+		nonCompliantDeviceCount?: number
+
 	    /** Number of error devices */
-		        errorDeviceCount: number
-	
+		errorDeviceCount?: number
+
 	    /** Number of conflict devices */
-		        conflictDeviceCount: number
-	
+		conflictDeviceCount?: number
+
 }
 
 export interface DeviceCompliancePolicySettingStateSummary extends Entity {
 
 	    /** The setting class name and property name. */
-		        setting?: string
-	
+		setting?: string
+
 	    /** Name of the setting. */
-		        settingName?: string
-	
+		settingName?: string
+
 	    /** Setting platform. Possible values are: android, iOS, macOS, windowsPhone81, windows81AndLater, windows10AndLater, androidWorkProfile, all. */
-		        platformType: PolicyPlatformType
-	
+		platformType?: PolicyPlatformType
+
 	    /** Number of unknown devices */
-		        unknownDeviceCount: number
-	
+		unknownDeviceCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableDeviceCount: number
-	
+		notApplicableDeviceCount?: number
+
 	    /** Number of compliant devices */
-		        compliantDeviceCount: number
-	
+		compliantDeviceCount?: number
+
 	    /** Number of remediated devices */
-		        remediatedDeviceCount: number
-	
+		remediatedDeviceCount?: number
+
 	    /** Number of NonCompliant devices */
-		        nonCompliantDeviceCount: number
-	
+		nonCompliantDeviceCount?: number
+
 	    /** Number of error devices */
-		        errorDeviceCount: number
-	
+		errorDeviceCount?: number
+
 	    /** Number of conflict devices */
-		        conflictDeviceCount: number
-	
+		conflictDeviceCount?: number
+
 	    /** Not yet documented */
-		        deviceComplianceSettingStates?: DeviceComplianceSettingState[]
-	
+		deviceComplianceSettingStates?: DeviceComplianceSettingState[]
+
 }
 
 export interface DeviceConfigurationDeviceStateSummary extends Entity {
 
 	    /** Number of unknown devices */
-		        unknownDeviceCount: number
-	
+		unknownDeviceCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableDeviceCount: number
-	
+		notApplicableDeviceCount?: number
+
 	    /** Number of compliant devices */
-		        compliantDeviceCount: number
-	
+		compliantDeviceCount?: number
+
 	    /** Number of remediated devices */
-		        remediatedDeviceCount: number
-	
+		remediatedDeviceCount?: number
+
 	    /** Number of NonCompliant devices */
-		        nonCompliantDeviceCount: number
-	
+		nonCompliantDeviceCount?: number
+
 	    /** Number of error devices */
-		        errorDeviceCount: number
-	
+		errorDeviceCount?: number
+
 	    /** Number of conflict devices */
-		        conflictDeviceCount: number
-	
+		conflictDeviceCount?: number
+
 }
 
 export interface IosUpdateDeviceStatus extends Entity {
 
 	    /** The installation status of the policy report. Possible values are: success, available, idle, downloading, downloadFailed, downloadRequiresComputer, downloadInsufficientSpace, downloadInsufficientPower, downloadInsufficientNetwork, installing, installInsufficientSpace, installInsufficientPower, installPhoneCallInProgress, installFailed, notSupportedOperation, sharedDeviceUserLoggedInError. */
-		        installStatus: IosUpdatesInstallStatus
-	
+		installStatus?: IosUpdatesInstallStatus
+
 	    /** The device version that is being reported. */
-		        osVersion?: string
-	
+		osVersion?: string
+
 	    /** The device id that is being reported. */
-		        deviceId?: string
-	
+		deviceId?: string
+
 	    /** The User id that is being reported. */
-		        userId?: string
-	
+		userId?: string
+
 	    /** Device name of the DevicePolicyStatus. */
-		        deviceDisplayName?: string
-	
+		deviceDisplayName?: string
+
 	    /** The User Name that is being reported */
-		        userName?: string
-	
+		userName?: string
+
 	    /** The device model that is being reported */
-		        deviceModel?: string
-	
+		deviceModel?: string
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface DeviceCategory extends Entity {
 
 	    /** Display name for the device category. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Optional description for the device category. */
-		        description?: string
-	
+		description?: string
+
 }
 
 export interface DeviceManagementExchangeConnector extends Entity {
 
 	    /** Last sync time for the Exchange Connector */
-		        lastSyncDateTime: string
-	
+		lastSyncDateTime?: string
+
 	    /** Exchange Connector Status. Possible values are: none, connectionPending, connected, disconnected. */
-		        status: DeviceManagementExchangeConnectorStatus
-	
+		status?: DeviceManagementExchangeConnectorStatus
+
 	    /** Email address used to configure the Service To Service Exchange Connector. */
-		        primarySmtpAddress?: string
-	
+		primarySmtpAddress?: string
+
 	    /** The name of the server hosting the Exchange Connector. */
-		        serverName?: string
-	
-		        connectorServerName?: string
-	
+		serverName?: string
+
+		connectorServerName?: string
+
 	    /** The type of Exchange Connector Configured. Possible values are: onPremises, hosted, serviceToService, dedicated. */
-		        exchangeConnectorType: DeviceManagementExchangeConnectorType
-	
+		exchangeConnectorType?: DeviceManagementExchangeConnectorType
+
 	    /** The version of the ExchangeConnectorAgent */
-		        version?: string
-	
+		version?: string
+
 	    /** An alias assigned to the Exchange server */
-		        exchangeAlias?: string
-	
+		exchangeAlias?: string
+
 	    /** Exchange Organization to the Exchange server */
-		        exchangeOrganization?: string
-	
+		exchangeOrganization?: string
+
 }
 
 export interface DeviceEnrollmentConfiguration extends Entity {
 
 	    /** Not yet documented */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Not yet documented */
-		        description?: string
-	
+		description?: string
+
 	    /** Not yet documented */
-		        priority: number
-	
+		priority?: number
+
 	    /** Not yet documented */
-		        createdDateTime: string
-	
+		createdDateTime?: string
+
 	    /** Not yet documented */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Not yet documented */
-		        version: number
-	
+		version?: number
+
 	    /** The list of group assignments for the device configuration profile. */
-		        assignments?: EnrollmentConfigurationAssignment[]
-	
+		assignments?: EnrollmentConfigurationAssignment[]
+
 }
 
 export interface OnPremisesConditionalAccessSettings extends Entity {
 
 	    /** Indicates if on premises conditional access is enabled for this organization */
-		        enabled: boolean
-	
+		enabled?: boolean
+
 	    /** User groups that will be targeted by on premises conditional access. All users in these groups will be required to have mobile device managed and compliant for mail access. */
-		        includedGroups: string[]
-	
+		includedGroups?: string[]
+
 	    /** User groups that will be exempt by on premises conditional access. All users in these groups will be exempt from the conditional access policy. */
-		        excludedGroups: string[]
-	
+		excludedGroups?: string[]
+
 	    /** Override the default access rule when allowing a device to ensure access is granted. */
-		        overrideDefaultRule: boolean
-	
+		overrideDefaultRule?: boolean
+
 }
 
 export interface MobileThreatDefenseConnector extends Entity {
 
 	    /** DateTime of last Heartbeat recieved from the Data Sync Partner */
-		        lastHeartbeatDateTime: string
-	
+		lastHeartbeatDateTime?: string
+
 	    /** Data Sync Partner state for this account. Possible values are: unavailable, available, enabled, unresponsive. */
-		        partnerState: MobileThreatPartnerTenantState
-	
+		partnerState?: MobileThreatPartnerTenantState
+
 	    /** For Android, set whether data from the data sync partner should be used during compliance evaluations */
-		        androidEnabled: boolean
-	
+		androidEnabled?: boolean
+
 	    /** For IOS, get or set whether data from the data sync partner should be used during compliance evaluations */
-		        iosEnabled: boolean
-	
+		iosEnabled?: boolean
+
 	    /** For Android, set whether Intune must receive data from the data sync partner prior to marking a device compliant */
-		        androidDeviceBlockedOnMissingPartnerData: boolean
-	
+		androidDeviceBlockedOnMissingPartnerData?: boolean
+
 	    /** For IOS, set whether Intune must receive data from the data sync partner prior to marking a device compliant */
-		        iosDeviceBlockedOnMissingPartnerData: boolean
-	
+		iosDeviceBlockedOnMissingPartnerData?: boolean
+
 	    /** Get or set whether to block devices on the enabled platforms that do not meet the minimum version requirements of the Data Sync Partner */
-		        partnerUnsupportedOsVersionBlocked: boolean
-	
+		partnerUnsupportedOsVersionBlocked?: boolean
+
 	    /** Get or Set days the per tenant tolerance to unresponsiveness for this partner integration */
-		        partnerUnresponsivenessThresholdInDays: number
-	
+		partnerUnresponsivenessThresholdInDays?: number
+
 }
 
 export interface DeviceManagementPartner extends Entity {
 
 	    /** Timestamp of last heartbeat after admin enabled option Connect to Device management Partner */
-		        lastHeartbeatDateTime: string
-	
+		lastHeartbeatDateTime?: string
+
 	    /** Partner state of this tenant. Possible values are: unknown, unavailable, enabled, terminated, rejected, unresponsive. */
-		        partnerState: DeviceManagementPartnerTenantState
-	
+		partnerState?: DeviceManagementPartnerTenantState
+
 	    /** Partner App type. Possible values are: unknown, singleTenantApp, multiTenantApp. */
-		        partnerAppType: DeviceManagementPartnerAppType
-	
+		partnerAppType?: DeviceManagementPartnerAppType
+
 	    /** Partner Single tenant App id */
-		        singleTenantAppId?: string
-	
+		singleTenantAppId?: string
+
 	    /** Partner display name */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Whether device management partner is configured or not */
-		        isConfigured: boolean
-	
+		isConfigured?: boolean
+
 	    /** DateTime in UTC when PartnerDevices will be removed */
-		        whenPartnerDevicesWillBeRemovedDateTime?: string
-	
+		whenPartnerDevicesWillBeRemovedDateTime?: string
+
 	    /** DateTime in UTC when PartnerDevices will be marked as NonCompliant */
-		        whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime?: string
-	
+		whenPartnerDevicesWillBeMarkedAsNonCompliantDateTime?: string
+
 }
 
 export interface NotificationMessageTemplate extends Entity {
 
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** Display name for the Notification Message Template. */
-		        displayName: string
-	
+		displayName?: string
+
 	    /** The default locale to fallback onto when the requested locale is not available. */
-		        defaultLocale?: string
-	
+		defaultLocale?: string
+
 	    /** The Message Template Branding Options. Branding is defined in the Intune Admin Console. Possible values are: none, includeCompanyLogo, includeCompanyName, includeContactInformation. */
-		        brandingOptions: NotificationTemplateBrandingOptions
-	
+		brandingOptions?: NotificationTemplateBrandingOptions
+
 	    /** The list of localized messages for this Notification Message Template. */
-		        localizedNotificationMessages?: LocalizedNotificationMessage[]
-	
+		localizedNotificationMessages?: LocalizedNotificationMessage[]
+
 }
 
 export interface RoleDefinition extends Entity {
 
 	    /** Display Name of the Role definition. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Description of the Role definition. */
-		        description?: string
-	
+		description?: string
+
 	    /** List of Role Permissions this role is allowed to perform. These must match the actionName that is defined as part of the rolePermission. */
-		        rolePermissions?: RolePermission[]
-	
+		rolePermissions?: RolePermission[]
+
 	    /** Type of Role. Set to True if it is built-in, or set to False if it is a custom role definition. */
-		        isBuiltIn: boolean
-	
+		isBuiltIn?: boolean
+
 	    /** List of Role assignments for this role definition. */
-		        roleAssignments?: RoleAssignment[]
-	
+		roleAssignments?: RoleAssignment[]
+
 }
 
 export interface RoleAssignment extends Entity {
 
 	    /** The display or friendly name of the role Assignment. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Description of the Role Assignment. */
-		        description?: string
-	
+		description?: string
+
 	    /** List of ids of role scope member security groups.  These are IDs from Azure Active Directory. */
-		        resourceScopes?: string[]
-	
+		resourceScopes?: string[]
+
 	    /** Role definition this assignment is part of. */
-		        roleDefinition?: RoleDefinition
-	
+		roleDefinition?: RoleDefinition
+
 }
 
 export interface DeviceAndAppManagementRoleAssignment extends RoleAssignment {
 
 	    /** The list of ids of role member security groups. These are IDs from Azure Active Directory. */
-		        members?: string[]
-	
+		members?: string[]
+
 }
 
 export interface ResourceOperation extends Entity {
 
 	    /** Name of the Resource this operation is performed on. */
-		        resourceName?: string
-	
+		resourceName?: string
+
 	    /** Type of action this operation is going to perform. The actionName should be concise and limited to as few words as possible. */
-		        actionName?: string
-	
+		actionName?: string
+
 	    /** Description of the resource operation. The description is used in mouse-over text for the operation when shown in the Azure Portal. */
-		        description?: string
-	
+		description?: string
+
 }
 
 export interface TelecomExpenseManagementPartner extends Entity {
 
 	    /** Display name of the TEM partner. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** URL of the TEM partner's administrative control panel, where an administrator can configure their TEM service. */
-		        url?: string
-	
+		url?: string
+
 	    /** Whether the partner's AAD app has been authorized to access Intune. */
-		        appAuthorized: boolean
-	
+		appAuthorized?: boolean
+
 	    /** Whether Intune's connection to the TEM service is currently enabled or disabled. */
-		        enabled: boolean
-	
+		enabled?: boolean
+
 	    /** Timestamp of the last request sent to Intune by the TEM partner. */
-		        lastConnectionDateTime: string
-	
+		lastConnectionDateTime?: string
+
 }
 
 export interface RemoteAssistancePartner extends Entity {
 
 	    /** Display name of the partner. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** URL of the partner's onboarding portal, where an administrator can configure their Remote Assistance service. */
-		        onboardingUrl?: string
-	
+		onboardingUrl?: string
+
 	    /** TBD. Possible values are: notOnboarded, onboarding, onboarded. */
-		        onboardingStatus: RemoteAssistanceOnboardingStatus
-	
+		onboardingStatus?: RemoteAssistanceOnboardingStatus
+
 	    /** Timestamp of the last request sent to Intune by the TEM partner. */
-		        lastConnectionDateTime: string
-	
+		lastConnectionDateTime?: string
+
 }
 
 export interface WindowsInformationProtectionAppLearningSummary extends Entity {
 
 	    /** Application Name */
-		        applicationName?: string
-	
+		applicationName?: string
+
 	    /** Application Type. Possible values are: universal, desktop. */
-		        applicationType: ApplicationType
-	
+		applicationType?: ApplicationType
+
 	    /** Device Count */
-		        deviceCount: number
-	
+		deviceCount?: number
+
 }
 
 export interface WindowsInformationProtectionNetworkLearningSummary extends Entity {
 
 	    /** Website url */
-		        url?: string
-	
+		url?: string
+
 	    /** Device Count */
-		        deviceCount: number
-	
+		deviceCount?: number
+
 }
 
 export interface TermsAndConditionsAssignment extends Entity {
 
 	    /** Assignment target that the T&C policy is assigned to. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface TermsAndConditionsAcceptanceStatus extends Entity {
 
 	    /** Display name of the user whose acceptance the entity represents. */
-		        userDisplayName?: string
-	
+		userDisplayName?: string
+
 	    /** Most recent version number of the T&C accepted by the user. */
-		        acceptedVersion: number
-	
+		acceptedVersion?: number
+
 	    /** DateTime when the terms were last accepted by the user. */
-		        acceptedDateTime: string
-	
+		acceptedDateTime?: string
+
 	    /** Navigation link to the terms and conditions that are assigned. */
-		        termsAndConditions?: TermsAndConditions
-	
+		termsAndConditions?: TermsAndConditions
+
 }
 
 export interface DeviceConfigurationState extends Entity {
 
-		        settingStates?: DeviceConfigurationSettingState[]
-	
-		        displayName?: string
-	
-		        version: number
-	
-		        platformType: PolicyPlatformType
-	
-		        state: ComplianceStatus
-	
-		        settingCount: number
-	
+		settingStates?: DeviceConfigurationSettingState[]
+
+		displayName?: string
+
+		version?: number
+
+		platformType?: PolicyPlatformType
+
+		state?: ComplianceStatus
+
+		settingCount?: number
+
 }
 
 export interface DeviceCompliancePolicyState extends Entity {
 
-		        settingStates?: DeviceCompliancePolicySettingState[]
-	
-		        displayName?: string
-	
-		        version: number
-	
-		        platformType: PolicyPlatformType
-	
-		        state: ComplianceStatus
-	
-		        settingCount: number
-	
+		settingStates?: DeviceCompliancePolicySettingState[]
+
+		displayName?: string
+
+		version?: number
+
+		platformType?: PolicyPlatformType
+
+		state?: ComplianceStatus
+
+		settingCount?: number
+
 }
 
 export interface DeviceConfigurationAssignment extends Entity {
 
 	    /** The assignment target for the device configuration. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface DeviceConfigurationDeviceStatus extends Entity {
 
 	    /** Device name of the DevicePolicyStatus. */
-		        deviceDisplayName?: string
-	
+		deviceDisplayName?: string
+
 	    /** The User Name that is being reported */
-		        userName?: string
-	
+		userName?: string
+
 	    /** The device model that is being reported */
-		        deviceModel?: string
-	
+		deviceModel?: string
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface DeviceConfigurationUserStatus extends Entity {
 
 	    /** User name of the DevicePolicyStatus. */
-		        userDisplayName?: string
-	
+		userDisplayName?: string
+
 	    /** Devices count for that user. */
-		        devicesCount: number
-	
+		devicesCount?: number
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface DeviceConfigurationDeviceOverview extends Entity {
 
 	    /** Number of pending devices */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded devices */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error devices */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed devices */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface DeviceConfigurationUserOverview extends Entity {
 
 	    /** Number of pending Users */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded Users */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error Users */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed Users */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface SettingStateDeviceSummary extends Entity {
 
 	    /** Name of the setting */
-		        settingName?: string
-	
+		settingName?: string
+
 	    /** Name of the InstancePath for the setting */
-		        instancePath?: string
-	
+		instancePath?: string
+
 	    /** Device Unkown count for the setting */
-		        unknownDeviceCount: number
-	
+		unknownDeviceCount?: number
+
 	    /** Device Not Applicable count for the setting */
-		        notApplicableDeviceCount: number
-	
+		notApplicableDeviceCount?: number
+
 	    /** Device Compliant count for the setting */
-		        compliantDeviceCount: number
-	
+		compliantDeviceCount?: number
+
 	    /** Device Compliant count for the setting */
-		        remediatedDeviceCount: number
-	
+		remediatedDeviceCount?: number
+
 	    /** Device NonCompliant count for the setting */
-		        nonCompliantDeviceCount: number
-	
+		nonCompliantDeviceCount?: number
+
 	    /** Device error count for the setting */
-		        errorDeviceCount: number
-	
+		errorDeviceCount?: number
+
 	    /** Device conflict error count for the setting */
-		        conflictDeviceCount: number
-	
+		conflictDeviceCount?: number
+
 }
 
 export interface DeviceCompliancePolicyAssignment extends Entity {
 
 	    /** Target for the compliance policy assignment. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface DeviceComplianceScheduledActionForRule extends Entity {
 
 	    /** Name of the rule which this scheduled action applies to. */
-		        ruleName?: string
-	
+		ruleName?: string
+
 	    /** The list of scheduled action configurations for this compliance policy. */
-		        scheduledActionConfigurations?: DeviceComplianceActionItem[]
-	
+		scheduledActionConfigurations?: DeviceComplianceActionItem[]
+
 }
 
 export interface DeviceComplianceDeviceStatus extends Entity {
 
 	    /** Device name of the DevicePolicyStatus. */
-		        deviceDisplayName?: string
-	
+		deviceDisplayName?: string
+
 	    /** The User Name that is being reported */
-		        userName?: string
-	
+		userName?: string
+
 	    /** The device model that is being reported */
-		        deviceModel?: string
-	
+		deviceModel?: string
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface DeviceComplianceUserStatus extends Entity {
 
 	    /** User name of the DevicePolicyStatus. */
-		        userDisplayName?: string
-	
+		userDisplayName?: string
+
 	    /** Devices count for that user. */
-		        devicesCount: number
-	
+		devicesCount?: number
+
 	    /** Compliance status of the policy report. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        status: ComplianceStatus
-	
+		status?: ComplianceStatus
+
 	    /** Last modified date time of the policy report. */
-		        lastReportedDateTime: string
-	
+		lastReportedDateTime?: string
+
 	    /** UserPrincipalName. */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 }
 
 export interface DeviceComplianceDeviceOverview extends Entity {
 
 	    /** Number of pending devices */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded devices */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error devices */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed devices */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface DeviceComplianceUserOverview extends Entity {
 
 	    /** Number of pending Users */
-		        pendingCount: number
-	
+		pendingCount?: number
+
 	    /** Number of not applicable devices */
-		        notApplicableCount: number
-	
+		notApplicableCount?: number
+
 	    /** Number of succeeded Users */
-		        successCount: number
-	
+		successCount?: number
+
 	    /** Number of error Users */
-		        errorCount: number
-	
+		errorCount?: number
+
 	    /** Number of failed Users */
-		        failedCount: number
-	
+		failedCount?: number
+
 	    /** Last update time */
-		        lastUpdateDateTime: string
-	
+		lastUpdateDateTime?: string
+
 	    /** Version of the policy for that overview */
-		        configurationVersion: number
-	
+		configurationVersion?: number
+
 }
 
 export interface DeviceComplianceActionItem extends Entity {
 
 	    /** Number of hours to wait till the action will be enforced. Valid values 0 to 8760 */
-		        gracePeriodHours: number
-	
+		gracePeriodHours?: number
+
 	    /** What action to take. Possible values are: noAction, notification, block, retire, wipe, removeResourceAccessProfiles. */
-		        actionType: DeviceComplianceActionType
-	
+		actionType?: DeviceComplianceActionType
+
 	    /** What notification Message template to use */
-		        notificationTemplateId?: string
-	
+		notificationTemplateId?: string
+
 	    /** A list of group IDs to speicify who to CC this notification message to. */
-		        notificationMessageCCList?: string[]
-	
+		notificationMessageCCList?: string[]
+
 }
 
 export interface AndroidCustomConfiguration extends DeviceConfiguration {
 
 	    /** OMA settings. This collection can contain a maximum of 1000 elements. */
-		        omaSettings?: OmaSetting[]
-	
+		omaSettings?: OmaSetting[]
+
 }
 
 export interface AndroidGeneralDeviceConfiguration extends DeviceConfiguration {
 
 	    /** Indicates whether or not to block clipboard sharing to copy and paste between applications. */
-		        appsBlockClipboardSharing: boolean
-	
+		appsBlockClipboardSharing?: boolean
+
 	    /** Indicates whether or not to block copy and paste within applications. */
-		        appsBlockCopyPaste: boolean
-	
+		appsBlockCopyPaste?: boolean
+
 	    /** Indicates whether or not to block the YouTube app. */
-		        appsBlockYouTube: boolean
-	
+		appsBlockYouTube?: boolean
+
 	    /** Indicates whether or not to block Bluetooth. */
-		        bluetoothBlocked: boolean
-	
+		bluetoothBlocked?: boolean
+
 	    /** Indicates whether or not to block the use of the camera. */
-		        cameraBlocked: boolean
-	
+		cameraBlocked?: boolean
+
 	    /** Indicates whether or not to block data roaming. */
-		        cellularBlockDataRoaming: boolean
-	
+		cellularBlockDataRoaming?: boolean
+
 	    /** Indicates whether or not to block SMS/MMS messaging. */
-		        cellularBlockMessaging: boolean
-	
+		cellularBlockMessaging?: boolean
+
 	    /** Indicates whether or not to block voice roaming. */
-		        cellularBlockVoiceRoaming: boolean
-	
+		cellularBlockVoiceRoaming?: boolean
+
 	    /** Indicates whether or not to block syncing Wi-Fi tethering. */
-		        cellularBlockWiFiTethering: boolean
-	
+		cellularBlockWiFiTethering?: boolean
+
 	    /** List of apps in the compliance (either allow list or block list, controlled by CompliantAppListType). This collection can contain a maximum of 10000 elements. */
-		        compliantAppsList?: AppListItem[]
-	
+		compliantAppsList?: AppListItem[]
+
 	    /** Type of list that is in the CompliantAppsList. Possible values are: none, appsInListCompliant, appsNotInListCompliant. */
-		        compliantAppListType: AppListType
-	
+		compliantAppListType?: AppListType
+
 	    /** Indicates whether or not to block diagnostic data submission. */
-		        diagnosticDataBlockSubmission: boolean
-	
+		diagnosticDataBlockSubmission?: boolean
+
 	    /** Indicates whether or not to block location services. */
-		        locationServicesBlocked: boolean
-	
+		locationServicesBlocked?: boolean
+
 	    /** Indicates whether or not to block Google account auto sync. */
-		        googleAccountBlockAutoSync: boolean
-	
+		googleAccountBlockAutoSync?: boolean
+
 	    /** Indicates whether or not to block the Google Play store. */
-		        googlePlayStoreBlocked: boolean
-	
+		googlePlayStoreBlocked?: boolean
+
 	    /** Indicates whether or not to block the screen sleep button while in Kiosk Mode. */
-		        kioskModeBlockSleepButton: boolean
-	
+		kioskModeBlockSleepButton?: boolean
+
 	    /** Indicates whether or not to block the volume buttons while in Kiosk Mode. */
-		        kioskModeBlockVolumeButtons: boolean
-	
+		kioskModeBlockVolumeButtons?: boolean
+
 	    /** A list of apps that will be allowed to run when the device is in Kiosk Mode. This collection can contain a maximum of 500 elements. */
-		        kioskModeApps?: AppListItem[]
-	
+		kioskModeApps?: AppListItem[]
+
 	    /** Indicates whether or not to block Near-Field Communication. */
-		        nfcBlocked: boolean
-	
+		nfcBlocked?: boolean
+
 	    /** Indicates whether or not to block fingerprint unlock. */
-		        passwordBlockFingerprintUnlock: boolean
-	
+		passwordBlockFingerprintUnlock?: boolean
+
 	    /** Indicates whether or not to block Smart Lock and other trust agents. */
-		        passwordBlockTrustAgents: boolean
-	
+		passwordBlockTrustAgents?: boolean
+
 	    /** Number of days before the password expires. Valid values 1 to 365 */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Minimum length of passwords. Valid values 4 to 16 */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity before the screen times out. */
-		        passwordMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** Number of previous passwords to block. Valid values 0 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Number of sign in failures allowed before factory reset. Valid values 4 to 11 */
-		        passwordSignInFailureCountBeforeFactoryReset?: number
-	
+		passwordSignInFailureCountBeforeFactoryReset?: number
+
 	    /** Type of password that is required. Possible values are: deviceDefault, alphabetic, alphanumeric, alphanumericWithSymbols, lowSecurityBiometric, numeric, numericComplex, any. */
-		        passwordRequiredType: AndroidRequiredPasswordType
-	
+		passwordRequiredType?: AndroidRequiredPasswordType
+
 	    /** Indicates whether or not to require a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to block powering off the device. */
-		        powerOffBlocked: boolean
-	
+		powerOffBlocked?: boolean
+
 	    /** Indicates whether or not to block user performing a factory reset. */
-		        factoryResetBlocked: boolean
-	
+		factoryResetBlocked?: boolean
+
 	    /** Indicates whether or not to block screenshots. */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** Indicates whether or not to allow device sharing mode. */
-		        deviceSharingAllowed: boolean
-	
+		deviceSharingAllowed?: boolean
+
 	    /** Indicates whether or not to block Google Backup. */
-		        storageBlockGoogleBackup: boolean
-	
+		storageBlockGoogleBackup?: boolean
+
 	    /** Indicates whether or not to block removable storage usage. */
-		        storageBlockRemovableStorage: boolean
-	
+		storageBlockRemovableStorage?: boolean
+
 	    /** Indicates whether or not to require device encryption. */
-		        storageRequireDeviceEncryption: boolean
-	
+		storageRequireDeviceEncryption?: boolean
+
 	    /** Indicates whether or not to require removable storage encryption. */
-		        storageRequireRemovableStorageEncryption: boolean
-	
+		storageRequireRemovableStorageEncryption?: boolean
+
 	    /** Indicates whether or not to block the use of the Voice Assistant. */
-		        voiceAssistantBlocked: boolean
-	
+		voiceAssistantBlocked?: boolean
+
 	    /** Indicates whether or not to block voice dialing. */
-		        voiceDialingBlocked: boolean
-	
+		voiceDialingBlocked?: boolean
+
 	    /** Indicates whether or not to block popups within the web browser. */
-		        webBrowserBlockPopups: boolean
-	
+		webBrowserBlockPopups?: boolean
+
 	    /** Indicates whether or not to block the web browser's auto fill feature. */
-		        webBrowserBlockAutofill: boolean
-	
+		webBrowserBlockAutofill?: boolean
+
 	    /** Indicates whether or not to block JavaScript within the web browser. */
-		        webBrowserBlockJavaScript: boolean
-	
+		webBrowserBlockJavaScript?: boolean
+
 	    /** Indicates whether or not to block the web browser. */
-		        webBrowserBlocked: boolean
-	
+		webBrowserBlocked?: boolean
+
 	    /** Cookie settings within the web browser. Possible values are: browserDefault, blockAlways, allowCurrentWebSite, allowFromWebsitesVisited, allowAlways. */
-		        webBrowserCookieSettings: WebBrowserCookieSettings
-	
+		webBrowserCookieSettings?: WebBrowserCookieSettings
+
 	    /** Indicates whether or not to block syncing Wi-Fi. */
-		        wiFiBlocked: boolean
-	
+		wiFiBlocked?: boolean
+
 	    /** List of apps which can be installed on the KNOX device. This collection can contain a maximum of 500 elements. */
-		        appsInstallAllowList?: AppListItem[]
-	
+		appsInstallAllowList?: AppListItem[]
+
 	    /** List of apps which are blocked from being launched on the KNOX device. This collection can contain a maximum of 500 elements. */
-		        appsLaunchBlockList?: AppListItem[]
-	
+		appsLaunchBlockList?: AppListItem[]
+
 	    /** List of apps to be hidden on the KNOX device. This collection can contain a maximum of 500 elements. */
-		        appsHideList?: AppListItem[]
-	
+		appsHideList?: AppListItem[]
+
 	    /** Require the Android Verify apps feature is turned on. */
-		        securityRequireVerifyApps: boolean
-	
+		securityRequireVerifyApps?: boolean
+
+}
+
+export interface AndroidWorkProfileCustomConfiguration extends DeviceConfiguration {
+
+		omaSettings?: OmaSetting[]
+
+}
+
+export interface AndroidWorkProfileGeneralDeviceConfiguration extends DeviceConfiguration {
+
+		passwordBlockFingerprintUnlock?: boolean
+
+		passwordBlockTrustAgents?: boolean
+
+		passwordExpirationDays?: number
+
+		passwordMinimumLength?: number
+
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
+		passwordPreviousPasswordBlockCount?: number
+
+		passwordSignInFailureCountBeforeFactoryReset?: number
+
+		passwordRequiredType?: AndroidWorkProfileRequiredPasswordType
+
+		workProfileDataSharingType?: AndroidWorkProfileCrossProfileDataSharingType
+
+		workProfileBlockNotificationsWhileDeviceLocked?: boolean
+
+		workProfileBlockAddingAccounts?: boolean
+
+		workProfileBluetoothEnableContactSharing?: boolean
+
+		workProfileBlockScreenCapture?: boolean
+
+		workProfileBlockCrossProfileCallerId?: boolean
+
+		workProfileBlockCamera?: boolean
+
+		workProfileBlockCrossProfileContactsSearch?: boolean
+
+		workProfileBlockCrossProfileCopyPaste?: boolean
+
+		workProfileDefaultAppPermissionPolicy?: AndroidWorkProfileDefaultAppPermissionPolicyType
+
+		workProfilePasswordBlockFingerprintUnlock?: boolean
+
+		workProfilePasswordBlockTrustAgents?: boolean
+
+		workProfilePasswordExpirationDays?: number
+
+		workProfilePasswordMinimumLength?: number
+
+		workProfilePasswordMinNumericCharacters?: number
+
+		workProfilePasswordMinNonLetterCharacters?: number
+
+		workProfilePasswordMinLetterCharacters?: number
+
+		workProfilePasswordMinLowerCaseCharacters?: number
+
+		workProfilePasswordMinUpperCaseCharacters?: number
+
+		workProfilePasswordMinSymbolCharacters?: number
+
+		workProfilePasswordMinutesOfInactivityBeforeScreenTimeout?: number
+
+		workProfilePasswordPreviousPasswordBlockCount?: number
+
+		workProfilePasswordSignInFailureCountBeforeFactoryReset?: number
+
+		workProfilePasswordRequiredType?: AndroidWorkProfileRequiredPasswordType
+
+		workProfileRequirePassword?: boolean
+
+		securityRequireVerifyApps?: boolean
+
 }
 
 export interface IosCertificateProfile extends DeviceConfiguration {
@@ -5642,477 +5773,479 @@ export interface IosCertificateProfile extends DeviceConfiguration {
 export interface IosCustomConfiguration extends DeviceConfiguration {
 
 	    /** Name that is displayed to the user. */
-		        payloadName: string
-	
+		payloadName?: string
+
 	    /** Payload file name (.mobileconfig */
-		        payloadFileName?: string
-	
+		payloadFileName?: string
+
 	    /** Payload. (UTF8 encoded byte array) */
-		        payload: number
-	
+		payload?: number
+
 }
 
 export interface IosGeneralDeviceConfiguration extends DeviceConfiguration {
 
 	    /** Indicates whether or not to allow account modification when the device is in supervised mode. */
-		        accountBlockModification: boolean
-	
+		accountBlockModification?: boolean
+
 	    /** Indicates whether or not to allow activation lock when the device is in the supervised mode. */
-		        activationLockAllowWhenSupervised: boolean
-	
+		activationLockAllowWhenSupervised?: boolean
+
 	    /** Indicates whether or not to allow AirDrop when the device is in supervised mode. */
-		        airDropBlocked: boolean
-	
+		airDropBlocked?: boolean
+
 	    /** Indicates whether or not to cause AirDrop to be considered an unmanaged drop target (iOS 9.0 and later). */
-		        airDropForceUnmanagedDropTarget: boolean
-	
+		airDropForceUnmanagedDropTarget?: boolean
+
 	    /** Indicates whether or not to enforce all devices receiving AirPlay requests from this device to use a pairing password. */
-		        airPlayForcePairingPasswordForOutgoingRequests: boolean
-	
+		airPlayForcePairingPasswordForOutgoingRequests?: boolean
+
 	    /** Indicates whether or not to allow Apple Watch pairing when the device is in supervised mode (iOS 9.0 and later). */
-		        appleWatchBlockPairing: boolean
-	
+		appleWatchBlockPairing?: boolean
+
 	    /** Indicates whether or not to force a paired Apple Watch to use Wrist Detection (iOS 8.2 and later). */
-		        appleWatchForceWristDetection: boolean
-	
+		appleWatchForceWristDetection?: boolean
+
 	    /** Indicates whether or not to block the user from using News when the device is in supervised mode (iOS 9.0 and later). */
-		        appleNewsBlocked: boolean
-	
+		appleNewsBlocked?: boolean
+
 	    /** Gets or sets the list of iOS apps allowed to autonomously enter Single App Mode. Supervised only. iOS 7.0 and later. This collection can contain a maximum of 500 elements. */
-		        appsSingleAppModeList?: AppListItem[]
-	
+		appsSingleAppModeList?: AppListItem[]
+
 	    /** List of apps in the visibility list (either visible/launchable apps list or hidden/unlaunchable apps list, controlled by AppsVisibilityListType) (iOS 9.3 and later). This collection can contain a maximum of 10000 elements. */
-		        appsVisibilityList?: AppListItem[]
-	
+		appsVisibilityList?: AppListItem[]
+
 	    /** Type of list that is in the AppsVisibilityList. Possible values are: none, appsInListCompliant, appsNotInListCompliant. */
-		        appsVisibilityListType: AppListType
-	
+		appsVisibilityListType?: AppListType
+
 	    /** Indicates whether or not to block the automatic downloading of apps purchased on other devices when the device is in supervised mode (iOS 9.0 and later). */
-		        appStoreBlockAutomaticDownloads: boolean
-	
+		appStoreBlockAutomaticDownloads?: boolean
+
 	    /** Indicates whether or not to block the user from using the App Store. */
-		        appStoreBlocked: boolean
-	
+		appStoreBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from making in app purchases. */
-		        appStoreBlockInAppPurchases: boolean
-	
+		appStoreBlockInAppPurchases?: boolean
+
 	    /** Indicates whether or not to block the App Store app, not restricting installation through Host apps. Applies to supervised mode only (iOS 9.0 and later). */
-		        appStoreBlockUIAppInstallation: boolean
-	
+		appStoreBlockUIAppInstallation?: boolean
+
 	    /** Indicates whether or not to require a password when using the app store. */
-		        appStoreRequirePassword: boolean
-	
+		appStoreRequirePassword?: boolean
+
 	    /** Indicates whether or not to allow modification of Bluetooth settings when the device is in supervised mode (iOS 10.0 and later). */
-		        bluetoothBlockModification: boolean
-	
+		bluetoothBlockModification?: boolean
+
 	    /** Indicates whether or not to block the user from accessing the camera of the device. */
-		        cameraBlocked: boolean
-	
+		cameraBlocked?: boolean
+
 	    /** Indicates whether or not to block data roaming. */
-		        cellularBlockDataRoaming: boolean
-	
+		cellularBlockDataRoaming?: boolean
+
 	    /** Indicates whether or not to block global background fetch while roaming. */
-		        cellularBlockGlobalBackgroundFetchWhileRoaming: boolean
-	
+		cellularBlockGlobalBackgroundFetchWhileRoaming?: boolean
+
 	    /** Indicates whether or not to allow changes to cellular app data usage settings when the device is in supervised mode. */
-		        cellularBlockPerAppDataModification: boolean
-	
+		cellularBlockPerAppDataModification?: boolean
+
 	    /** Indicates whether or not to block Personal Hotspot. */
-		        cellularBlockPersonalHotspot: boolean
-	
+		cellularBlockPersonalHotspot?: boolean
+
 	    /** Indicates whether or not to block voice roaming. */
-		        cellularBlockVoiceRoaming: boolean
-	
+		cellularBlockVoiceRoaming?: boolean
+
 	    /** Indicates whether or not to block untrusted TLS certificates. */
-		        certificatesBlockUntrustedTlsCertificates: boolean
-	
+		certificatesBlockUntrustedTlsCertificates?: boolean
+
 	    /** Indicates whether or not to allow remote screen observation by Classroom app when the device is in supervised mode (iOS 9.3 and later). */
-		        classroomAppBlockRemoteScreenObservation: boolean
-	
+		classroomAppBlockRemoteScreenObservation?: boolean
+
 	    /** Indicates whether or not to automatically give permission to the teacher of a managed course on the Classroom app to view a student's screen without prompting when the device is in supervised mode. */
-		        classroomAppForceUnpromptedScreenObservation: boolean
-	
+		classroomAppForceUnpromptedScreenObservation?: boolean
+
 	    /** List of apps in the compliance (either allow list or block list, controlled by CompliantAppListType). This collection can contain a maximum of 10000 elements. */
-		        compliantAppsList?: AppListItem[]
-	
+		compliantAppsList?: AppListItem[]
+
 	    /** List that is in the AppComplianceList. Possible values are: none, appsInListCompliant, appsNotInListCompliant. */
-		        compliantAppListType: AppListType
-	
+		compliantAppListType?: AppListType
+
 	    /** Indicates whether or not to block the user from installing configuration profiles and certificates interactively when the device is in supervised mode. */
-		        configurationProfileBlockChanges: boolean
-	
+		configurationProfileBlockChanges?: boolean
+
 	    /** Indicates whether or not to block definition lookup when the device is in supervised mode (iOS 8.1.3 and later ). */
-		        definitionLookupBlocked: boolean
-	
+		definitionLookupBlocked?: boolean
+
 	    /** Indicates whether or not to allow the user to enables restrictions in the device settings when the device is in supervised mode. */
-		        deviceBlockEnableRestrictions: boolean
-	
+		deviceBlockEnableRestrictions?: boolean
+
 	    /** Indicates whether or not to allow the use of the 'Erase all content and settings' option on the device when the device is in supervised mode. */
-		        deviceBlockEraseContentAndSettings: boolean
-	
+		deviceBlockEraseContentAndSettings?: boolean
+
 	    /** Indicates whether or not to allow device name modification when the device is in supervised mode (iOS 9.0 and later). */
-		        deviceBlockNameModification: boolean
-	
+		deviceBlockNameModification?: boolean
+
 	    /** Indicates whether or not to block diagnostic data submission. */
-		        diagnosticDataBlockSubmission: boolean
-	
+		diagnosticDataBlockSubmission?: boolean
+
 	    /** Indicates whether or not to allow diagnostics submission settings modification when the device is in supervised mode (iOS 9.3.2 and later). */
-		        diagnosticDataBlockSubmissionModification: boolean
-	
+		diagnosticDataBlockSubmissionModification?: boolean
+
 	    /** Indicates whether or not to block the user from viewing managed documents in unmanaged apps. */
-		        documentsBlockManagedDocumentsInUnmanagedApps: boolean
-	
+		documentsBlockManagedDocumentsInUnmanagedApps?: boolean
+
 	    /** Indicates whether or not to block the user from viewing unmanaged documents in managed apps. */
-		        documentsBlockUnmanagedDocumentsInManagedApps: boolean
-	
+		documentsBlockUnmanagedDocumentsInManagedApps?: boolean
+
 	    /** An email address lacking a suffix that matches any of these strings will be considered out-of-domain. */
-		        emailInDomainSuffixes?: string[]
-	
+		emailInDomainSuffixes?: string[]
+
 	    /** Indicates whether or not to block the user from trusting an enterprise app. */
-		        enterpriseAppBlockTrust: boolean
-	
+		enterpriseAppBlockTrust?: boolean
+
 	    /** Indicates whether or not to block the user from modifying the enterprise app trust settings. */
-		        enterpriseAppBlockTrustModification: boolean
-	
+		enterpriseAppBlockTrustModification?: boolean
+
 	    /** Indicates whether or not to block the user from using FaceTime. */
-		        faceTimeBlocked: boolean
-	
+		faceTimeBlocked?: boolean
+
 	    /** Indicates whether or not to block Find My Friends when the device is in supervised mode. */
-		        findMyFriendsBlocked: boolean
-	
+		findMyFriendsBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from having friends in Game Center. */
-		        gamingBlockGameCenterFriends: boolean
-	
+		gamingBlockGameCenterFriends?: boolean
+
 	    /** Indicates whether or not to block the user from using multiplayer gaming. */
-		        gamingBlockMultiplayer: boolean
-	
+		gamingBlockMultiplayer?: boolean
+
 	    /** Indicates whether or not to block the user from using Game Center when the device is in supervised mode. */
-		        gameCenterBlocked: boolean
-	
+		gameCenterBlocked?: boolean
+
 	    /** indicates whether or not to allow host pairing to control the devices an iOS device can pair with when the iOS device is in supervised mode. */
-		        hostPairingBlocked: boolean
-	
+		hostPairingBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from using the iBooks Store when the device is in supervised mode. */
-		        iBooksStoreBlocked: boolean
-	
+		iBooksStoreBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from downloading media from the iBookstore that has been tagged as erotica. */
-		        iBooksStoreBlockErotica: boolean
-	
+		iBooksStoreBlockErotica?: boolean
+
 	    /** Indicates whether or not to block  the the user from continuing work they started on iOS device to another iOS or macOS device. */
-		        iCloudBlockActivityContinuation: boolean
-	
+		iCloudBlockActivityContinuation?: boolean
+
 	    /** Indicates whether or not to block iCloud backup. */
-		        iCloudBlockBackup: boolean
-	
+		iCloudBlockBackup?: boolean
+
 	    /** Indicates whether or not to block iCloud document sync. */
-		        iCloudBlockDocumentSync: boolean
-	
+		iCloudBlockDocumentSync?: boolean
+
 	    /** Indicates whether or not to block Managed Apps Cloud Sync. */
-		        iCloudBlockManagedAppsSync: boolean
-	
+		iCloudBlockManagedAppsSync?: boolean
+
 	    /** Indicates whether or not to block iCloud Photo Library. */
-		        iCloudBlockPhotoLibrary: boolean
-	
+		iCloudBlockPhotoLibrary?: boolean
+
 	    /** Indicates whether or not to block iCloud Photo Stream Sync. */
-		        iCloudBlockPhotoStreamSync: boolean
-	
+		iCloudBlockPhotoStreamSync?: boolean
+
 	    /** Indicates whether or not to block Shared Photo Stream. */
-		        iCloudBlockSharedPhotoStream: boolean
-	
+		iCloudBlockSharedPhotoStream?: boolean
+
 	    /** Indicates whether or not to require backups to iCloud be encrypted. */
-		        iCloudRequireEncryptedBackup: boolean
-	
+		iCloudRequireEncryptedBackup?: boolean
+
 	    /** Indicates whether or not to block the user from accessing explicit content in iTunes and the App Store. */
-		        iTunesBlockExplicitContent: boolean
-	
+		iTunesBlockExplicitContent?: boolean
+
 	    /** Indicates whether or not to block Music service and revert Music app to classic mode when the device is in supervised mode (iOS 9.3 and later and macOS 10.12 and later). */
-		        iTunesBlockMusicService: boolean
-	
+		iTunesBlockMusicService?: boolean
+
 	    /** Indicates whether or not to block the user from using iTunes Radio when the device is in supervised mode (iOS 9.3 and later). */
-		        iTunesBlockRadio: boolean
-	
+		iTunesBlockRadio?: boolean
+
 	    /** Indicates whether or not to block keyboard auto-correction when the device is in supervised mode (iOS 8.1.3 and later). */
-		        keyboardBlockAutoCorrect: boolean
-	
+		keyboardBlockAutoCorrect?: boolean
+
 	    /** Indicates whether or not to block the user from using dictation input when the device is in supervised mode. */
-		        keyboardBlockDictation: boolean
-	
+		keyboardBlockDictation?: boolean
+
 	    /** Indicates whether or not to block predictive keyboards when device is in supervised mode (iOS 8.1.3 and later). */
-		        keyboardBlockPredictive: boolean
-	
+		keyboardBlockPredictive?: boolean
+
 	    /** Indicates whether or not to block keyboard shortcuts when the device is in supervised mode (iOS 9.0 and later). */
-		        keyboardBlockShortcuts: boolean
-	
+		keyboardBlockShortcuts?: boolean
+
 	    /** Indicates whether or not to block keyboard spell-checking when the device is in supervised mode (iOS 8.1.3 and later). */
-		        keyboardBlockSpellCheck: boolean
-	
+		keyboardBlockSpellCheck?: boolean
+
 	    /** Indicates whether or not to allow assistive speak while in kiosk mode. */
-		        kioskModeAllowAssistiveSpeak: boolean
-	
+		kioskModeAllowAssistiveSpeak?: boolean
+
 	    /** Indicates whether or not to allow access to the Assistive Touch Settings while in kiosk mode. */
-		        kioskModeAllowAssistiveTouchSettings: boolean
-	
+		kioskModeAllowAssistiveTouchSettings?: boolean
+
 	    /** Indicates whether or not to allow device auto lock while in kiosk mode. */
-		        kioskModeAllowAutoLock: boolean
-	
+		kioskModeAllowAutoLock?: boolean
+
 	    /** Indicates whether or not to allow access to the Color Inversion Settings while in kiosk mode. */
-		        kioskModeAllowColorInversionSettings: boolean
-	
+		kioskModeAllowColorInversionSettings?: boolean
+
 	    /** Indicates whether or not to allow use of the ringer switch while in kiosk mode. */
-		        kioskModeAllowRingerSwitch: boolean
-	
+		kioskModeAllowRingerSwitch?: boolean
+
 	    /** Indicates whether or not to allow screen rotation while in kiosk mode. */
-		        kioskModeAllowScreenRotation: boolean
-	
+		kioskModeAllowScreenRotation?: boolean
+
 	    /** Indicates whether or not to allow use of the sleep button while in kiosk mode. */
-		        kioskModeAllowSleepButton: boolean
-	
+		kioskModeAllowSleepButton?: boolean
+
 	    /** Indicates whether or not to allow use of the touchscreen while in kiosk mode. */
-		        kioskModeAllowTouchscreen: boolean
-	
+		kioskModeAllowTouchscreen?: boolean
+
 	    /** Indicates whether or not to allow access to the voice over settings while in kiosk mode. */
-		        kioskModeAllowVoiceOverSettings: boolean
-	
+		kioskModeAllowVoiceOverSettings?: boolean
+
 	    /** Indicates whether or not to allow use of the volume buttons while in kiosk mode. */
-		        kioskModeAllowVolumeButtons: boolean
-	
+		kioskModeAllowVolumeButtons?: boolean
+
 	    /** Indicates whether or not to allow access to the zoom settings while in kiosk mode. */
-		        kioskModeAllowZoomSettings: boolean
-	
+		kioskModeAllowZoomSettings?: boolean
+
 	    /** URL in the app store to the app to use for kiosk mode. Use if KioskModeManagedAppId is not known. */
-		        kioskModeAppStoreUrl?: string
-	
+		kioskModeAppStoreUrl?: string
+
+		kioskModeBuiltInAppId?: string
+
 	    /** Indicates whether or not to require assistive touch while in kiosk mode. */
-		        kioskModeRequireAssistiveTouch: boolean
-	
+		kioskModeRequireAssistiveTouch?: boolean
+
 	    /** Indicates whether or not to require color inversion while in kiosk mode. */
-		        kioskModeRequireColorInversion: boolean
-	
+		kioskModeRequireColorInversion?: boolean
+
 	    /** Indicates whether or not to require mono audio while in kiosk mode. */
-		        kioskModeRequireMonoAudio: boolean
-	
+		kioskModeRequireMonoAudio?: boolean
+
 	    /** Indicates whether or not to require voice over while in kiosk mode. */
-		        kioskModeRequireVoiceOver: boolean
-	
+		kioskModeRequireVoiceOver?: boolean
+
 	    /** Indicates whether or not to require zoom while in kiosk mode. */
-		        kioskModeRequireZoom: boolean
-	
+		kioskModeRequireZoom?: boolean
+
 	    /** Managed app id of the app to use for kiosk mode. If KioskModeManagedAppId is specified then KioskModeAppStoreUrl will be ignored. */
-		        kioskModeManagedAppId?: string
-	
+		kioskModeManagedAppId?: string
+
 	    /** Indicates whether or not to block the user from using control center on the lock screen. */
-		        lockScreenBlockControlCenter: boolean
-	
+		lockScreenBlockControlCenter?: boolean
+
 	    /** Indicates whether or not to block the user from using the notification view on the lock screen. */
-		        lockScreenBlockNotificationView: boolean
-	
+		lockScreenBlockNotificationView?: boolean
+
 	    /** Indicates whether or not to block the user from using passbook when the device is locked. */
-		        lockScreenBlockPassbook: boolean
-	
+		lockScreenBlockPassbook?: boolean
+
 	    /** Indicates whether or not to block the user from using the Today View on the lock screen. */
-		        lockScreenBlockTodayView: boolean
-	
+		lockScreenBlockTodayView?: boolean
+
 	    /** Media content rating settings for Australia */
-		        mediaContentRatingAustralia?: MediaContentRatingAustralia
-	
+		mediaContentRatingAustralia?: MediaContentRatingAustralia
+
 	    /** Media content rating settings for Canada */
-		        mediaContentRatingCanada?: MediaContentRatingCanada
-	
+		mediaContentRatingCanada?: MediaContentRatingCanada
+
 	    /** Media content rating settings for France */
-		        mediaContentRatingFrance?: MediaContentRatingFrance
-	
+		mediaContentRatingFrance?: MediaContentRatingFrance
+
 	    /** Media content rating settings for Germany */
-		        mediaContentRatingGermany?: MediaContentRatingGermany
-	
+		mediaContentRatingGermany?: MediaContentRatingGermany
+
 	    /** Media content rating settings for Ireland */
-		        mediaContentRatingIreland?: MediaContentRatingIreland
-	
+		mediaContentRatingIreland?: MediaContentRatingIreland
+
 	    /** Media content rating settings for Japan */
-		        mediaContentRatingJapan?: MediaContentRatingJapan
-	
+		mediaContentRatingJapan?: MediaContentRatingJapan
+
 	    /** Media content rating settings for New Zealand */
-		        mediaContentRatingNewZealand?: MediaContentRatingNewZealand
-	
+		mediaContentRatingNewZealand?: MediaContentRatingNewZealand
+
 	    /** Media content rating settings for United Kingdom */
-		        mediaContentRatingUnitedKingdom?: MediaContentRatingUnitedKingdom
-	
+		mediaContentRatingUnitedKingdom?: MediaContentRatingUnitedKingdom
+
 	    /** Media content rating settings for United States */
-		        mediaContentRatingUnitedStates?: MediaContentRatingUnitedStates
-	
+		mediaContentRatingUnitedStates?: MediaContentRatingUnitedStates
+
 	    /** List of managed apps and the network rules that applies to them. This collection can contain a maximum of 1000 elements. */
-		        networkUsageRules?: IosNetworkUsageRule[]
-	
+		networkUsageRules?: IosNetworkUsageRule[]
+
 	    /** Media content rating settings for Apps. Possible values are: allAllowed, allBlocked, agesAbove4, agesAbove9, agesAbove12, agesAbove17. */
-		        mediaContentRatingApps: RatingAppsType
-	
+		mediaContentRatingApps?: RatingAppsType
+
 	    /** Indicates whether or not to block the user from using the Messages app on the supervised device. */
-		        messagesBlocked: boolean
-	
+		messagesBlocked?: boolean
+
 	    /** Indicates whether or not to allow notifications settings modification (iOS 9.3 and later). */
-		        notificationsBlockSettingsModification: boolean
-	
+		notificationsBlockSettingsModification?: boolean
+
 	    /** Indicates whether or not to block fingerprint unlock. */
-		        passcodeBlockFingerprintUnlock: boolean
-	
+		passcodeBlockFingerprintUnlock?: boolean
+
 	    /** Block modification of registered Touch ID fingerprints when in supervised mode. */
-		        passcodeBlockFingerprintModification: boolean
-	
+		passcodeBlockFingerprintModification?: boolean
+
 	    /** Indicates whether or not to allow passcode modification on the supervised device (iOS 9.0 and later). */
-		        passcodeBlockModification: boolean
-	
+		passcodeBlockModification?: boolean
+
 	    /** Indicates whether or not to block simple passcodes. */
-		        passcodeBlockSimple: boolean
-	
+		passcodeBlockSimple?: boolean
+
 	    /** Number of days before the passcode expires. Valid values 1 to 65535 */
-		        passcodeExpirationDays?: number
-	
+		passcodeExpirationDays?: number
+
 	    /** Minimum length of passcode. Valid values 4 to 14 */
-		        passcodeMinimumLength?: number
-	
+		passcodeMinimumLength?: number
+
 	    /** Minutes of inactivity before a passcode is required. */
-		        passcodeMinutesOfInactivityBeforeLock?: number
-	
+		passcodeMinutesOfInactivityBeforeLock?: number
+
 	    /** Minutes of inactivity before the screen times out. */
-		        passcodeMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passcodeMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** Number of character sets a passcode must contain. Valid values 0 to 4 */
-		        passcodeMinimumCharacterSetCount?: number
-	
+		passcodeMinimumCharacterSetCount?: number
+
 	    /** Number of previous passcodes to block. Valid values 1 to 24 */
-		        passcodePreviousPasscodeBlockCount?: number
-	
+		passcodePreviousPasscodeBlockCount?: number
+
 	    /** Number of sign in failures allowed before wiping the device. Valid values 4 to 11 */
-		        passcodeSignInFailureCountBeforeWipe?: number
-	
+		passcodeSignInFailureCountBeforeWipe?: number
+
 	    /** Type of passcode that is required. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passcodeRequiredType: RequiredPasswordType
-	
+		passcodeRequiredType?: RequiredPasswordType
+
 	    /** Indicates whether or not to require a passcode. */
-		        passcodeRequired: boolean
-	
+		passcodeRequired?: boolean
+
 	    /** Indicates whether or not to block the user from using podcasts on the supervised device (iOS 8.0 and later). */
-		        podcastsBlocked: boolean
-	
+		podcastsBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from using Auto fill in Safari. */
-		        safariBlockAutofill: boolean
-	
+		safariBlockAutofill?: boolean
+
 	    /** Indicates whether or not to block JavaScript in Safari. */
-		        safariBlockJavaScript: boolean
-	
+		safariBlockJavaScript?: boolean
+
 	    /** Indicates whether or not to block popups in Safari. */
-		        safariBlockPopups: boolean
-	
+		safariBlockPopups?: boolean
+
 	    /** Indicates whether or not to block the user from using Safari. */
-		        safariBlocked: boolean
-	
+		safariBlocked?: boolean
+
 	    /** Cookie settings for Safari. Possible values are: browserDefault, blockAlways, allowCurrentWebSite, allowFromWebsitesVisited, allowAlways. */
-		        safariCookieSettings: WebBrowserCookieSettings
-	
+		safariCookieSettings?: WebBrowserCookieSettings
+
 	    /** URLs matching the patterns listed here will be considered managed. */
-		        safariManagedDomains?: string[]
-	
+		safariManagedDomains?: string[]
+
 	    /** Users can save passwords in Safari only from URLs matching the patterns listed here. Applies to devices in supervised mode (iOS 9.3 and later). */
-		        safariPasswordAutoFillDomains?: string[]
-	
+		safariPasswordAutoFillDomains?: string[]
+
 	    /** Indicates whether or not to require fraud warning in Safari. */
-		        safariRequireFraudWarning: boolean
-	
+		safariRequireFraudWarning?: boolean
+
 	    /** Indicates whether or not to block the user from taking Screenshots. */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from using Siri. */
-		        siriBlocked: boolean
-	
+		siriBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from using Siri when locked. */
-		        siriBlockedWhenLocked: boolean
-	
+		siriBlockedWhenLocked?: boolean
+
 	    /** Indicates whether or not to block Siri from querying user-generated content when used on a supervised device. */
-		        siriBlockUserGeneratedContent: boolean
-	
+		siriBlockUserGeneratedContent?: boolean
+
 	    /** Indicates whether or not to prevent Siri from dictating, or speaking profane language on supervised device. */
-		        siriRequireProfanityFilter: boolean
-	
+		siriRequireProfanityFilter?: boolean
+
 	    /** Indicates whether or not to block Spotlight search from returning internet results on supervised device. */
-		        spotlightBlockInternetResults: boolean
-	
+		spotlightBlockInternetResults?: boolean
+
 	    /** Indicates whether or not to block voice dialing. */
-		        voiceDialingBlocked: boolean
-	
+		voiceDialingBlocked?: boolean
+
 	    /** Indicates whether or not to allow wallpaper modification on supervised device (iOS 9.0 and later) . */
-		        wallpaperBlockModification: boolean
-	
+		wallpaperBlockModification?: boolean
+
 	    /** Indicates whether or not to force the device to use only Wi-Fi networks from configuration profiles when the device is in supervised mode. */
-		        wiFiConnectOnlyToConfiguredNetworks: boolean
-	
+		wiFiConnectOnlyToConfiguredNetworks?: boolean
+
 }
 
 export interface IosUpdateConfiguration extends DeviceConfiguration {
 
 	    /** Active Hours Start (active hours mean the time window when updates install should not happen) */
-		        activeHoursStart: string
-	
+		activeHoursStart?: string
+
 	    /** Active Hours End (active hours mean the time window when updates install should not happen) */
-		        activeHoursEnd: string
-	
+		activeHoursEnd?: string
+
 	    /** Days in week for which active hours are configured. This collection can contain a maximum of 7 elements. */
-		        scheduledInstallDays: DayOfWeek[]
-	
+		scheduledInstallDays?: DayOfWeek[]
+
 	    /** UTC Time Offset indicated in minutes */
-		        utcTimeOffsetInMinutes: number
-	
+		utcTimeOffsetInMinutes?: number
+
 }
 
 export interface MacOSCustomConfiguration extends DeviceConfiguration {
 
 	    /** Name that is displayed to the user. */
-		        payloadName: string
-	
+		payloadName?: string
+
 	    /** Payload file name (.mobileconfig */
-		        payloadFileName?: string
-	
+		payloadFileName?: string
+
 	    /** Payload. (UTF8 encoded byte array) */
-		        payload: number
-	
+		payload?: number
+
 }
 
 export interface MacOSGeneralDeviceConfiguration extends DeviceConfiguration {
 
 	    /** List of apps in the compliance (either allow list or block list, controlled by CompliantAppListType). This collection can contain a maximum of 10000 elements. */
-		        compliantAppsList?: AppListItem[]
-	
+		compliantAppsList?: AppListItem[]
+
 	    /** List that is in the CompliantAppsList. Possible values are: none, appsInListCompliant, appsNotInListCompliant. */
-		        compliantAppListType: AppListType
-	
+		compliantAppListType?: AppListType
+
 	    /** An email address lacking a suffix that matches any of these strings will be considered out-of-domain. */
-		        emailInDomainSuffixes?: string[]
-	
+		emailInDomainSuffixes?: string[]
+
 	    /** Block simple passwords. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Number of days before the password expires. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Number of character sets a password must contain. Valid values 0 to 4 */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** Minimum length of passwords. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity required before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** Minutes of inactivity required before the screen times out. */
-		        passwordMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** Number of previous passwords to block. */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Type of password that is required. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** Whether or not to require a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 }
 
 export interface AppleDeviceFeaturesConfigurationBase extends DeviceConfiguration {
@@ -6122,20 +6255,20 @@ export interface AppleDeviceFeaturesConfigurationBase extends DeviceConfiguratio
 export interface IosDeviceFeaturesConfiguration extends AppleDeviceFeaturesConfigurationBase {
 
 	    /** Asset tag information for the device, displayed on the login window and lock screen. */
-		        assetTagTemplate?: string
-	
+		assetTagTemplate?: string
+
 	    /** A footnote displayed on the login window and lock screen. Available in iOS 9.3.1 and later. */
-		        lockScreenFootnote?: string
-	
+		lockScreenFootnote?: string
+
 	    /** A list of app and folders to appear on the Home Screen Dock. This collection can contain a maximum of 500 elements. */
-		        homeScreenDockIcons?: IosHomeScreenItem[]
-	
+		homeScreenDockIcons?: IosHomeScreenItem[]
+
 	    /** A list of pages on the Home Screen. This collection can contain a maximum of 500 elements. */
-		        homeScreenPages?: IosHomeScreenPage[]
-	
+		homeScreenPages?: IosHomeScreenPage[]
+
 	    /** Notification settings for each bundle id. Applicable to devices in supervised mode only (iOS 9.3 and later). This collection can contain a maximum of 500 elements. */
-		        notificationSettings?: IosNotificationSettings[]
-	
+		notificationSettings?: IosNotificationSettings[]
+
 }
 
 export interface MacOSDeviceFeaturesConfiguration extends AppleDeviceFeaturesConfigurationBase {
@@ -6145,1651 +6278,1697 @@ export interface MacOSDeviceFeaturesConfiguration extends AppleDeviceFeaturesCon
 export interface WindowsDefenderAdvancedThreatProtectionConfiguration extends DeviceConfiguration {
 
 	    /** Windows Defender AdvancedThreatProtection "Allow Sample Sharing" Rule */
-		        allowSampleSharing: boolean
-	
+		allowSampleSharing?: boolean
+
 	    /** Expedite Windows Defender Advanced Threat Protection telemetry reporting frequency. */
-		        enableExpeditedTelemetryReporting: boolean
-	
+		enableExpeditedTelemetryReporting?: boolean
+
 }
 
 export interface EditionUpgradeConfiguration extends DeviceConfiguration {
 
 	    /** Edition Upgrade License Type. Possible values are: productKey, licenseFile. */
-		        licenseType: EditionUpgradeLicenseType
-	
+		licenseType?: EditionUpgradeLicenseType
+
 	    /** Edition Upgrade Target Edition. Possible values are: windows10Enterprise, windows10EnterpriseN, windows10Education, windows10EducationN, windows10MobileEnterprise, windows10HolographicEnterprise, windows10Professional, windows10ProfessionalN, windows10ProfessionalEducation, windows10ProfessionalEducationN, windows10ProfessionalWorkstation, windows10ProfessionalWorkstationN. */
-		        targetEdition: Windows10EditionType
-	
+		targetEdition?: Windows10EditionType
+
 	    /** Edition Upgrade License File Content. */
-		        license?: string
-	
+		license?: string
+
 	    /** Edition Upgrade Product Key. */
-		        productKey?: string
-	
+		productKey?: string
+
 }
 
 export interface Windows10EndpointProtectionConfiguration extends DeviceConfiguration {
 
 	    /** Blocks stateful FTP connections to the device */
-		        firewallBlockStatefulFTP: boolean
-	
+		firewallBlockStatefulFTP?: boolean
+
 	    /** Configures the idle timeout for security associations, in seconds, from 300 to 3600 inclusive. This is the period after which security associations will expire and be deleted. Valid values 300 to 3600 */
-		        firewallIdleTimeoutForSecurityAssociationInSeconds?: number
-	
+		firewallIdleTimeoutForSecurityAssociationInSeconds?: number
+
 	    /** Select the preshared key encoding to be used. Possible values are: deviceDefault, none, utF8. */
-		        firewallPreSharedKeyEncodingMethod: FirewallPreSharedKeyEncodingMethodType
-	
+		firewallPreSharedKeyEncodingMethod?: FirewallPreSharedKeyEncodingMethodType
+
 	    /** Configures IPSec exemptions to allow neighbor discovery IPv6 ICMP type-codes */
-		        firewallIPSecExemptionsAllowNeighborDiscovery: boolean
-	
+		firewallIPSecExemptionsAllowNeighborDiscovery?: boolean
+
 	    /** Configures IPSec exemptions to allow ICMP */
-		        firewallIPSecExemptionsAllowICMP: boolean
-	
+		firewallIPSecExemptionsAllowICMP?: boolean
+
 	    /** Configures IPSec exemptions to allow router discovery IPv6 ICMP type-codes */
-		        firewallIPSecExemptionsAllowRouterDiscovery: boolean
-	
+		firewallIPSecExemptionsAllowRouterDiscovery?: boolean
+
 	    /** Configures IPSec exemptions to allow both IPv4 and IPv6 DHCP traffic */
-		        firewallIPSecExemptionsAllowDHCP: boolean
-	
+		firewallIPSecExemptionsAllowDHCP?: boolean
+
 	    /** Specify how the certificate revocation list is to be enforced. Possible values are: deviceDefault, none, attempt, require. */
-		        firewallCertificateRevocationListCheckMethod: FirewallCertificateRevocationListCheckMethodType
-	
+		firewallCertificateRevocationListCheckMethod?: FirewallCertificateRevocationListCheckMethodType
+
 	    /** If an authentication set is not fully supported by a keying module, direct the module to ignore only unsupported authentication suites rather than the entire set */
-		        firewallMergeKeyingModuleSettings: boolean
-	
+		firewallMergeKeyingModuleSettings?: boolean
+
 	    /** Configures how packet queueing should be applied in the tunnel gateway scenario. Possible values are: deviceDefault, disabled, queueInbound, queueOutbound, queueBoth. */
-		        firewallPacketQueueingMethod: FirewallPacketQueueingMethodType
-	
+		firewallPacketQueueingMethod?: FirewallPacketQueueingMethodType
+
 	    /** Configures the firewall profile settings for domain networks */
-		        firewallProfileDomain?: WindowsFirewallNetworkProfile
-	
+		firewallProfileDomain?: WindowsFirewallNetworkProfile
+
 	    /** Configures the firewall profile settings for public networks */
-		        firewallProfilePublic?: WindowsFirewallNetworkProfile
-	
+		firewallProfilePublic?: WindowsFirewallNetworkProfile
+
 	    /** Configures the firewall profile settings for private networks */
-		        firewallProfilePrivate?: WindowsFirewallNetworkProfile
-	
+		firewallProfilePrivate?: WindowsFirewallNetworkProfile
+
 	    /** List of exe files and folders to be excluded from attack surface reduction rules */
-		        defenderAttackSurfaceReductionExcludedPaths?: string[]
-	
+		defenderAttackSurfaceReductionExcludedPaths?: string[]
+
 	    /** List of paths to exe that are allowed to access protected folders */
-		        defenderGuardedFoldersAllowedAppPaths?: string[]
-	
+		defenderGuardedFoldersAllowedAppPaths?: string[]
+
 	    /** List of folder paths to be added to the list of protected folders */
-		        defenderAdditionalGuardedFolders?: string[]
-	
+		defenderAdditionalGuardedFolders?: string[]
+
 	    /** Xml content containing information regarding exploit protection details. */
-		        defenderExploitProtectionXml?: number
-	
+		defenderExploitProtectionXml?: number
+
 	    /** Name of the file from which DefenderExploitProtectionXml was obtained. */
-		        defenderExploitProtectionXmlFileName?: string
-	
+		defenderExploitProtectionXmlFileName?: string
+
 	    /** Indicates whether or not to block user from overriding Exploit Protection settings. */
-		        defenderSecurityCenterBlockExploitProtectionOverride: boolean
-	
+		defenderSecurityCenterBlockExploitProtectionOverride?: boolean
+
 	    /** Enables the Admin to choose what types of app to allow on devices. Possible values are: notConfigured, enforceComponentsAndStoreApps, auditComponentsAndStoreApps, enforceComponentsStoreAppsAndSmartlocker, auditComponentsStoreAppsAndSmartlocker. */
-		        appLockerApplicationControl: AppLockerApplicationControlType
-	
+		appLockerApplicationControl?: AppLockerApplicationControlType
+
 	    /** Allows IT Admins to configure SmartScreen for Windows. */
-		        smartScreenEnableInShell: boolean
-	
+		smartScreenEnableInShell?: boolean
+
 	    /** Allows IT Admins to control whether users can can ignore SmartScreen warnings and run malicious files. */
-		        smartScreenBlockOverrideForFiles: boolean
-	
+		smartScreenBlockOverrideForFiles?: boolean
+
 	    /** Enable Windows Defender Application Guard */
-		        applicationGuardEnabled: boolean
-	
+		applicationGuardEnabled?: boolean
+
 	    /** Block clipboard to transfer image file, text file or neither of them. Possible values are: notConfigured, blockImageAndTextFile, blockImageFile, blockNone, blockTextFile. */
-		        applicationGuardBlockFileTransfer: ApplicationGuardBlockFileTransferType
-	
+		applicationGuardBlockFileTransfer?: ApplicationGuardBlockFileTransferType
+
 	    /** Block enterprise sites to load non-enterprise content, such as third party plug-ins */
-		        applicationGuardBlockNonEnterpriseContent: boolean
-	
+		applicationGuardBlockNonEnterpriseContent?: boolean
+
 	    /** Allow persisting user generated data inside the App Guard Containter (favorites, cookies, web passwords, etc.) */
-		        applicationGuardAllowPersistence: boolean
-	
+		applicationGuardAllowPersistence?: boolean
+
 	    /** Force auditing will persist Windows logs and events to meet security/compliance criteria (sample events are user login-logoff, use of privilege rights, software installation, system changes, etc.) */
-		        applicationGuardForceAuditing: boolean
-	
+		applicationGuardForceAuditing?: boolean
+
 	    /** Block clipboard to share data from Host to Container, or from Container to Host, or both ways, or neither ways. Possible values are: notConfigured, blockBoth, blockHostToContainer, blockContainerToHost, blockNone. */
-		        applicationGuardBlockClipboardSharing: ApplicationGuardBlockClipboardSharingType
-	
+		applicationGuardBlockClipboardSharing?: ApplicationGuardBlockClipboardSharingType
+
 	    /** Allow printing to PDF from Container */
-		        applicationGuardAllowPrintToPDF: boolean
-	
+		applicationGuardAllowPrintToPDF?: boolean
+
 	    /** Allow printing to XPS from Container */
-		        applicationGuardAllowPrintToXPS: boolean
-	
+		applicationGuardAllowPrintToXPS?: boolean
+
 	    /** Allow printing to Local Printers from Container */
-		        applicationGuardAllowPrintToLocalPrinters: boolean
-	
+		applicationGuardAllowPrintToLocalPrinters?: boolean
+
 	    /** Allow printing to Network Printers from Container */
-		        applicationGuardAllowPrintToNetworkPrinters: boolean
-	
+		applicationGuardAllowPrintToNetworkPrinters?: boolean
+
 	    /** Allows the Admin to disable the warning prompt for other disk encryption on the user machines. */
-		        bitLockerDisableWarningForOtherDiskEncryption: boolean
-	
+		bitLockerDisableWarningForOtherDiskEncryption?: boolean
+
 	    /** Allows the admin to require encryption to be turned on using BitLocker. This policy is valid only for a mobile SKU. */
-		        bitLockerEnableStorageCardEncryptionOnMobile: boolean
-	
+		bitLockerEnableStorageCardEncryptionOnMobile?: boolean
+
 	    /** Allows the admin to require encryption to be turned on using BitLocker. */
-		        bitLockerEncryptDevice: boolean
-	
+		bitLockerEncryptDevice?: boolean
+
 	    /** BitLocker Removable Drive Policy. */
-		        bitLockerRemovableDrivePolicy?: BitLockerRemovableDrivePolicy
-	
+		bitLockerRemovableDrivePolicy?: BitLockerRemovableDrivePolicy
+
 }
 
 export interface Windows10GeneralConfiguration extends DeviceConfiguration {
 
 	    /** Endpoint for discovering cloud printers. */
-		        enterpriseCloudPrintDiscoveryEndPoint?: string
-	
+		enterpriseCloudPrintDiscoveryEndPoint?: string
+
 	    /** Authentication endpoint for acquiring OAuth tokens. */
-		        enterpriseCloudPrintOAuthAuthority?: string
-	
+		enterpriseCloudPrintOAuthAuthority?: string
+
 	    /** GUID of a client application authorized to retrieve OAuth tokens from the OAuth Authority. */
-		        enterpriseCloudPrintOAuthClientIdentifier?: string
-	
+		enterpriseCloudPrintOAuthClientIdentifier?: string
+
 	    /** OAuth resource URI for print service as configured in the Azure portal. */
-		        enterpriseCloudPrintResourceIdentifier?: string
-	
+		enterpriseCloudPrintResourceIdentifier?: string
+
 	    /** Maximum number of printers that should be queried from a discovery endpoint. This is a mobile only setting. Valid values 1 to 65535 */
-		        enterpriseCloudPrintDiscoveryMaxLimit?: number
-	
+		enterpriseCloudPrintDiscoveryMaxLimit?: number
+
 	    /** OAuth resource URI for printer discovery service as configured in Azure portal. */
-		        enterpriseCloudPrintMopriaDiscoveryResourceIdentifier?: string
-	
+		enterpriseCloudPrintMopriaDiscoveryResourceIdentifier?: string
+
 	    /** Specifies if search can use diacritics. */
-		        searchBlockDiacritics: boolean
-	
+		searchBlockDiacritics?: boolean
+
 	    /** Specifies whether to use automatic language detection when indexing content and properties. */
-		        searchDisableAutoLanguageDetection: boolean
-	
+		searchDisableAutoLanguageDetection?: boolean
+
 	    /** Indicates whether or not to block indexing of WIP-protected items to prevent them from appearing in search results for Cortana or Explorer. */
-		        searchDisableIndexingEncryptedItems: boolean
-	
-	    /** Indicates whether or not to block remote queries of this computer’s index. */
-		        searchEnableRemoteQueries: boolean
-	
+		searchDisableIndexingEncryptedItems?: boolean
+
+	    /** Indicates whether or not to block remote queries of this computer's index. */
+		searchEnableRemoteQueries?: boolean
+
 	    /** Indicates whether or not to disable the search indexer backoff feature. */
-		        searchDisableIndexerBackoff: boolean
-	
+		searchDisableIndexerBackoff?: boolean
+
 	    /** Indicates whether or not to allow users to add locations on removable drives to libraries and to be indexed. */
-		        searchDisableIndexingRemovableDrive: boolean
-	
+		searchDisableIndexingRemovableDrive?: boolean
+
 	    /** Specifies minimum amount of hard drive space on the same drive as the index location before indexing stops. */
-		        searchEnableAutomaticIndexSizeManangement: boolean
-	
+		searchEnableAutomaticIndexSizeManangement?: boolean
+
 	    /** Gets or sets a value allowing the device to send diagnostic and usage telemetry data, such as Watson. Possible values are: userDefined, none, basic, enhanced, full. */
-		        diagnosticsDataSubmissionMode: DiagnosticDataSubmissionMode
-	
+		diagnosticsDataSubmissionMode?: DiagnosticDataSubmissionMode
+
 	    /** Gets or sets a value allowing IT admins to prevent apps and features from working with files on OneDrive. */
-		        oneDriveDisableFileSync: boolean
-	
+		oneDriveDisableFileSync?: boolean
+
 	    /** Allows IT Admins to control whether users are allowed to install apps from places other than the Store. */
-		        smartScreenEnableAppInstallControl: boolean
-	
+		smartScreenEnableAppInstallControl?: boolean
+
 	    /** A http or https Url to a jpg, jpeg or png image that needs to be downloaded and used as the Desktop Image or a file Url to a local image on the file system that needs to used as the Desktop Image. */
-		        personalizationDesktopImageUrl?: string
-	
+		personalizationDesktopImageUrl?: string
+
 	    /** A http or https Url to a jpg, jpeg or png image that neeeds to be downloaded and used as the Lock Screen Image or a file Url to a local image on the file system that needs to be used as the Lock Screen Image. */
-		        personalizationLockScreenImageUrl?: string
-	
+		personalizationLockScreenImageUrl?: string
+
 	    /** Specify a list of allowed Bluetooth services and profiles in hex formatted strings. */
-		        bluetoothAllowedServices?: string[]
-	
+		bluetoothAllowedServices?: string[]
+
 	    /** Whether or not to Block the user from using bluetooth advertising. */
-		        bluetoothBlockAdvertising: boolean
-	
+		bluetoothBlockAdvertising?: boolean
+
 	    /** Whether or not to Block the user from using bluetooth discoverable mode. */
-		        bluetoothBlockDiscoverableMode: boolean
-	
+		bluetoothBlockDiscoverableMode?: boolean
+
 	    /** Whether or not to block specific bundled Bluetooth peripherals to automatically pair with the host device. */
-		        bluetoothBlockPrePairing: boolean
-	
+		bluetoothBlockPrePairing?: boolean
+
 	    /** Indicates whether or not to block auto fill. */
-		        edgeBlockAutofill: boolean
-	
+		edgeBlockAutofill?: boolean
+
 	    /** Indicates whether or not to Block the user from using the Microsoft Edge browser. */
-		        edgeBlocked: boolean
-	
+		edgeBlocked?: boolean
+
 	    /** Indicates which cookies to block in the Microsoft Edge browser. Possible values are: userDefined, allow, blockThirdParty, blockAll. */
-		        edgeCookiePolicy: EdgeCookiePolicy
-	
+		edgeCookiePolicy?: EdgeCookiePolicy
+
 	    /** Indicates whether or not to block developer tools in the Microsoft Edge browser. */
-		        edgeBlockDeveloperTools: boolean
-	
+		edgeBlockDeveloperTools?: boolean
+
 	    /** Indicates whether or not to Block the user from sending the do not track header. */
-		        edgeBlockSendingDoNotTrackHeader: boolean
-	
+		edgeBlockSendingDoNotTrackHeader?: boolean
+
 	    /** Indicates whether or not to block extensions in the Microsoft Edge browser. */
-		        edgeBlockExtensions: boolean
-	
+		edgeBlockExtensions?: boolean
+
 	    /** Indicates whether or not to block InPrivate browsing on corporate networks, in the Microsoft Edge browser. */
-		        edgeBlockInPrivateBrowsing: boolean
-	
+		edgeBlockInPrivateBrowsing?: boolean
+
 	    /** Indicates whether or not to Block the user from using JavaScript. */
-		        edgeBlockJavaScript: boolean
-	
+		edgeBlockJavaScript?: boolean
+
 	    /** Indicates whether or not to Block password manager. */
-		        edgeBlockPasswordManager: boolean
-	
+		edgeBlockPasswordManager?: boolean
+
 	    /** Block the address bar dropdown functionality in Microsoft Edge. Disable this settings to minimize network connections from Microsoft Edge to Microsoft services. */
-		        edgeBlockAddressBarDropdown: boolean
-	
+		edgeBlockAddressBarDropdown?: boolean
+
 	    /** Block Microsoft compatibility list in Microsoft Edge. This list from Microsoft helps Edge properly display sites with known compatibility issues. */
-		        edgeBlockCompatibilityList: boolean
-	
+		edgeBlockCompatibilityList?: boolean
+
 	    /** Clear browsing data on exiting Microsoft Edge. */
-		        edgeClearBrowsingDataOnExit: boolean
-	
+		edgeClearBrowsingDataOnExit?: boolean
+
 	    /** Allow users to change Start pages on Microsoft Edge. Use the EdgeHomepageUrls to specify the Start pages that the user would see by default when they open Microsoft Edge. */
-		        edgeAllowStartPagesModification: boolean
-	
+		edgeAllowStartPagesModification?: boolean
+
 	    /** Block the Microsoft web page that opens on the first use of Microsoft Edge. This policy allows enterprises, like those enrolled in zero emissions configurations, to block this page. */
-		        edgeDisableFirstRunPage: boolean
-	
+		edgeDisableFirstRunPage?: boolean
+
 	    /** Block the collection of information by Microsoft for live tile creation when users pin a site to Start from Microsoft Edge. */
-		        edgeBlockLiveTileDataCollection: boolean
-	
+		edgeBlockLiveTileDataCollection?: boolean
+
 	    /** Enable favorites sync between Internet Explorer and Microsoft Edge. Additions, deletions, modifications and order changes to favorites are shared between browsers. */
-		        edgeSyncFavoritesWithInternetExplorer: boolean
-	
+		edgeSyncFavoritesWithInternetExplorer?: boolean
+
 	    /** Whether or not to Block the user from using data over cellular while roaming. */
-		        cellularBlockDataWhenRoaming: boolean
-	
+		cellularBlockDataWhenRoaming?: boolean
+
 	    /** Whether or not to Block the user from using VPN over cellular. */
-		        cellularBlockVpn: boolean
-	
+		cellularBlockVpn?: boolean
+
 	    /** Whether or not to Block the user from using VPN when roaming over cellular. */
-		        cellularBlockVpnWhenRoaming: boolean
-	
+		cellularBlockVpnWhenRoaming?: boolean
+
 	    /** Whether or not to block end user access to Defender. */
-		        defenderBlockEndUserAccess: boolean
-	
+		defenderBlockEndUserAccess?: boolean
+
 	    /** Number of days before deleting quarantined malware. Valid values 0 to 90 */
-		        defenderDaysBeforeDeletingQuarantinedMalware?: number
-	
-	    /** Gets or sets Defender’s actions to take on detected Malware per threat level. */
-		        defenderDetectedMalwareActions?: DefenderDetectedMalwareActions
-	
+		defenderDaysBeforeDeletingQuarantinedMalware?: number
+
+	    /** Gets or sets Defender's actions to take on detected Malware per threat level. */
+		defenderDetectedMalwareActions?: DefenderDetectedMalwareActions
+
 	    /** Defender day of the week for the system scan. Possible values are: userDefined, everyday, sunday, monday, tuesday, wednesday, thursday, friday, saturday. */
-		        defenderSystemScanSchedule: WeeklySchedule
-	
+		defenderSystemScanSchedule?: WeeklySchedule
+
 	    /** Files and folder to exclude from scans and real time protection. */
-		        defenderFilesAndFoldersToExclude?: string[]
-	
+		defenderFilesAndFoldersToExclude?: string[]
+
 	    /** File extensions to exclude from scans and real time protection. */
-		        defenderFileExtensionsToExclude?: string[]
-	
+		defenderFileExtensionsToExclude?: string[]
+
 	    /** Max CPU usage percentage during scan. Valid values 0 to 100 */
-		        defenderScanMaxCpu?: number
-	
+		defenderScanMaxCpu?: number
+
 	    /** Value for monitoring file activity. Possible values are: userDefined, disable, monitorAllFiles, monitorIncomingFilesOnly, monitorOutgoingFilesOnly. */
-		        defenderMonitorFileActivity: DefenderMonitorFileActivity
-	
+		defenderMonitorFileActivity?: DefenderMonitorFileActivity
+
 	    /** Processes to exclude from scans and real time protection. */
-		        defenderProcessesToExclude?: string[]
-	
+		defenderProcessesToExclude?: string[]
+
 	    /** The configuration for how to prompt user for sample submission. Possible values are: userDefined, alwaysPrompt, promptBeforeSendingPersonalData, neverSendData, sendAllDataWithoutPrompting. */
-		        defenderPromptForSampleSubmission: DefenderPromptForSampleSubmission
-	
+		defenderPromptForSampleSubmission?: DefenderPromptForSampleSubmission
+
 	    /** Indicates whether or not to require behavior monitoring. */
-		        defenderRequireBehaviorMonitoring: boolean
-	
+		defenderRequireBehaviorMonitoring?: boolean
+
 	    /** Indicates whether or not to require cloud protection. */
-		        defenderRequireCloudProtection: boolean
-	
+		defenderRequireCloudProtection?: boolean
+
 	    /** Indicates whether or not to require network inspection system. */
-		        defenderRequireNetworkInspectionSystem: boolean
-	
+		defenderRequireNetworkInspectionSystem?: boolean
+
 	    /** Indicates whether or not to require real time monitoring. */
-		        defenderRequireRealTimeMonitoring: boolean
-	
+		defenderRequireRealTimeMonitoring?: boolean
+
 	    /** Indicates whether or not to scan archive files. */
-		        defenderScanArchiveFiles: boolean
-	
+		defenderScanArchiveFiles?: boolean
+
 	    /** Indicates whether or not to scan downloads. */
-		        defenderScanDownloads: boolean
-	
+		defenderScanDownloads?: boolean
+
 	    /** Indicates whether or not to scan files opened from a network folder. */
-		        defenderScanNetworkFiles: boolean
-	
+		defenderScanNetworkFiles?: boolean
+
 	    /** Indicates whether or not to scan incoming mail messages. */
-		        defenderScanIncomingMail: boolean
-	
+		defenderScanIncomingMail?: boolean
+
 	    /** Indicates whether or not to scan mapped network drives during full scan. */
-		        defenderScanMappedNetworkDrivesDuringFullScan: boolean
-	
+		defenderScanMappedNetworkDrivesDuringFullScan?: boolean
+
 	    /** Indicates whether or not to scan removable drives during full scan. */
-		        defenderScanRemovableDrivesDuringFullScan: boolean
-	
+		defenderScanRemovableDrivesDuringFullScan?: boolean
+
 	    /** Indicates whether or not to scan scripts loaded in Internet Explorer browser. */
-		        defenderScanScriptsLoadedInInternetExplorer: boolean
-	
+		defenderScanScriptsLoadedInInternetExplorer?: boolean
+
 	    /** The signature update interval in hours. Specify 0 not to check. Valid values 0 to 24 */
-		        defenderSignatureUpdateIntervalInHours?: number
-	
+		defenderSignatureUpdateIntervalInHours?: number
+
 	    /** The defender system scan type. Possible values are: userDefined, disabled, quick, full. */
-		        defenderScanType: DefenderScanType
-	
+		defenderScanType?: DefenderScanType
+
 	    /** The defender time for the system scan. */
-		        defenderScheduledScanTime?: string
-	
+		defenderScheduledScanTime?: string
+
 	    /** The time to perform a daily quick scan. */
-		        defenderScheduledQuickScanTime?: string
-	
+		defenderScheduledQuickScanTime?: string
+
 	    /** Specifies the level of cloud-delivered protection. Possible values are: notConfigured, high, highPlus, zeroTolerance. */
-		        defenderCloudBlockLevel: DefenderCloudBlockLevelType
-	
+		defenderCloudBlockLevel?: DefenderCloudBlockLevelType
+
 	    /** Specify whether to show a user-configurable setting to control the screen timeout while on the lock screen of Windows 10 Mobile devices. If this policy is set to Allow, the value set by lockScreenTimeoutInSeconds is ignored. */
-		        lockScreenAllowTimeoutConfiguration: boolean
-	
+		lockScreenAllowTimeoutConfiguration?: boolean
+
 	    /** Indicates whether or not to block action center notifications over lock screen. */
-		        lockScreenBlockActionCenterNotifications: boolean
-	
+		lockScreenBlockActionCenterNotifications?: boolean
+
 	    /** Indicates whether or not the user can interact with Cortana using speech while the system is locked. */
-		        lockScreenBlockCortana: boolean
-	
+		lockScreenBlockCortana?: boolean
+
 	    /** Indicates whether to allow toast notifications above the device lock screen. */
-		        lockScreenBlockToastNotifications: boolean
-	
+		lockScreenBlockToastNotifications?: boolean
+
 	    /** Set the duration (in seconds) from the screen locking to the screen turning off for Windows 10 Mobile devices. Supported values are 11-1800. Valid values 11 to 1800 */
-		        lockScreenTimeoutInSeconds?: number
-	
+		lockScreenTimeoutInSeconds?: number
+
 	    /** Specify whether PINs or passwords such as "1111" or "1234" are allowed. For Windows 10 desktops, it also controls the use of picture passwords. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** The password expiration in days. Valid values 0 to 730 */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** The minimum password length. Valid values 4 to 16 */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** The minutes of inactivity before the screen times out. */
-		        passwordMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The number of previous passwords to prevent reuse of. Valid values 0 to 50 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Indicates whether or not to require the user to have a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to require a password upon resuming from an idle state. */
-		        passwordRequireWhenResumeFromIdleState: boolean
-	
+		passwordRequireWhenResumeFromIdleState?: boolean
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** The number of sign in failures before factory reset. Valid values 0 to 999 */
-		        passwordSignInFailureCountBeforeFactoryReset?: number
-	
+		passwordSignInFailureCountBeforeFactoryReset?: number
+
 	    /** Enables or disables the use of advertising ID. Added in Windows 10, version 1607. Possible values are: notConfigured, blocked, allowed. */
-		        privacyAdvertisingId: StateManagementSetting
-	
+		privacyAdvertisingId?: StateManagementSetting
+
 	    /** Indicates whether or not to allow the automatic acceptance of the pairing and privacy user consent dialog when launching apps. */
-		        privacyAutoAcceptPairingAndConsentPrompts: boolean
-	
+		privacyAutoAcceptPairingAndConsentPrompts?: boolean
+
 	    /** Indicates whether or not to block the usage of cloud based speech services for Cortana, Dictation, or Store applications. */
-		        privacyBlockInputPersonalization: boolean
-	
+		privacyBlockInputPersonalization?: boolean
+
 	    /** Indicates whether or not to block the user from unpinning apps from taskbar. */
-		        startBlockUnpinningAppsFromTaskbar: boolean
-	
+		startBlockUnpinningAppsFromTaskbar?: boolean
+
 	    /** Setting the value of this collapses the app list, removes the app list entirely, or disables the corresponding toggle in the Settings app. Possible values are: userDefined, collapse, remove, disableSettingsApp. */
-		        startMenuAppListVisibility: WindowsStartMenuAppListVisibilityType
-	
+		startMenuAppListVisibility?: WindowsStartMenuAppListVisibilityType
+
 	    /** Enabling this policy hides the change account setting from appearing in the user tile in the start menu. */
-		        startMenuHideChangeAccountSettings: boolean
-	
+		startMenuHideChangeAccountSettings?: boolean
+
 	    /** Enabling this policy hides the most used apps from appearing on the start menu and disables the corresponding toggle in the Settings app. */
-		        startMenuHideFrequentlyUsedApps: boolean
-	
+		startMenuHideFrequentlyUsedApps?: boolean
+
 	    /** Enabling this policy hides hibernate from appearing in the power button in the start menu. */
-		        startMenuHideHibernate: boolean
-	
+		startMenuHideHibernate?: boolean
+
 	    /** Enabling this policy hides lock from appearing in the user tile in the start menu. */
-		        startMenuHideLock: boolean
-	
+		startMenuHideLock?: boolean
+
 	    /** Enabling this policy hides the power button from appearing in the start menu. */
-		        startMenuHidePowerButton: boolean
-	
+		startMenuHidePowerButton?: boolean
+
 	    /** Enabling this policy hides recent jump lists from appearing on the start menu/taskbar and disables the corresponding toggle in the Settings app. */
-		        startMenuHideRecentJumpLists: boolean
-	
+		startMenuHideRecentJumpLists?: boolean
+
 	    /** Enabling this policy hides recently added apps from appearing on the start menu and disables the corresponding toggle in the Settings app. */
-		        startMenuHideRecentlyAddedApps: boolean
-	
-	    /** Enabling this policy hides “Restart/Update and Restart” from appearing in the power button in the start menu. */
-		        startMenuHideRestartOptions: boolean
-	
+		startMenuHideRecentlyAddedApps?: boolean
+
+	    /** Enabling this policy hides "Restart/Update and Restart" from appearing in the power button in the start menu. */
+		startMenuHideRestartOptions?: boolean
+
 	    /** Enabling this policy hides shut down/update and shut down from appearing in the power button in the start menu. */
-		        startMenuHideShutDown: boolean
-	
+		startMenuHideShutDown?: boolean
+
 	    /** Enabling this policy hides sign out from appearing in the user tile in the start menu. */
-		        startMenuHideSignOut: boolean
-	
+		startMenuHideSignOut?: boolean
+
 	    /** Enabling this policy hides sleep from appearing in the power button in the start menu. */
-		        startMenuHideSleep: boolean
-	
+		startMenuHideSleep?: boolean
+
 	    /** Enabling this policy hides switch account from appearing in the user tile in the start menu. */
-		        startMenuHideSwitchAccount: boolean
-	
+		startMenuHideSwitchAccount?: boolean
+
 	    /** Enabling this policy hides the user tile from appearing in the start menu. */
-		        startMenuHideUserTile: boolean
-	
+		startMenuHideUserTile?: boolean
+
 	    /** This policy setting allows you to import Microsoft Edge assets to be used with startMenuLayoutXml policy. Start layout can contain secondary tile from Microsoft Edge app which looks for Microsoft Edge local asset file. Microsoft Edge local asset would not exist and cause Microsoft Edge secondary tile to appear empty in this case. This policy only gets applied when startMenuLayoutXml policy is modified. The value should be a UTF-8 Base64 encoded byte array. */
-		        startMenuLayoutEdgeAssetsXml?: number
-	
+		startMenuLayoutEdgeAssetsXml?: number
+
 	    /** Allows admins to override the default Start menu layout and prevents the user from changing it. The layout is modified by specifying an XML file based on a layout modification schema. XML needs to be in a UTF8 encoded byte array format. */
-		        startMenuLayoutXml?: number
-	
+		startMenuLayoutXml?: number
+
 	    /** Allows admins to decide how the Start menu is displayed. Possible values are: userDefined, fullScreen, nonFullScreen. */
-		        startMenuMode: WindowsStartMenuModeType
-	
+		startMenuMode?: WindowsStartMenuModeType
+
 	    /** Enforces the visibility (Show/Hide) of the Documents folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderDocuments: VisibilitySetting
-	
+		startMenuPinnedFolderDocuments?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Downloads folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderDownloads: VisibilitySetting
-	
+		startMenuPinnedFolderDownloads?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the FileExplorer shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderFileExplorer: VisibilitySetting
-	
+		startMenuPinnedFolderFileExplorer?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the HomeGroup folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderHomeGroup: VisibilitySetting
-	
+		startMenuPinnedFolderHomeGroup?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Music folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderMusic: VisibilitySetting
-	
+		startMenuPinnedFolderMusic?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Network folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderNetwork: VisibilitySetting
-	
+		startMenuPinnedFolderNetwork?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the PersonalFolder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderPersonalFolder: VisibilitySetting
-	
+		startMenuPinnedFolderPersonalFolder?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Pictures folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderPictures: VisibilitySetting
-	
+		startMenuPinnedFolderPictures?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Settings folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderSettings: VisibilitySetting
-	
+		startMenuPinnedFolderSettings?: VisibilitySetting
+
 	    /** Enforces the visibility (Show/Hide) of the Videos folder shortcut on the Start menu. Possible values are: notConfigured, hide, show. */
-		        startMenuPinnedFolderVideos: VisibilitySetting
-	
+		startMenuPinnedFolderVideos?: VisibilitySetting
+
 	    /** Indicates whether or not to block access to Settings app. */
-		        settingsBlockSettingsApp: boolean
-	
+		settingsBlockSettingsApp?: boolean
+
 	    /** Indicates whether or not to block access to System in Settings app. */
-		        settingsBlockSystemPage: boolean
-	
+		settingsBlockSystemPage?: boolean
+
 	    /** Indicates whether or not to block access to Devices in Settings app. */
-		        settingsBlockDevicesPage: boolean
-	
+		settingsBlockDevicesPage?: boolean
+
 	    /** Indicates whether or not to block access to Network & Internet in Settings app. */
-		        settingsBlockNetworkInternetPage: boolean
-	
+		settingsBlockNetworkInternetPage?: boolean
+
 	    /** Indicates whether or not to block access to Personalization in Settings app. */
-		        settingsBlockPersonalizationPage: boolean
-	
+		settingsBlockPersonalizationPage?: boolean
+
 	    /** Indicates whether or not to block access to Accounts in Settings app. */
-		        settingsBlockAccountsPage: boolean
-	
+		settingsBlockAccountsPage?: boolean
+
 	    /** Indicates whether or not to block access to Time & Language in Settings app. */
-		        settingsBlockTimeLanguagePage: boolean
-	
+		settingsBlockTimeLanguagePage?: boolean
+
 	    /** Indicates whether or not to block access to Ease of Access in Settings app. */
-		        settingsBlockEaseOfAccessPage: boolean
-	
+		settingsBlockEaseOfAccessPage?: boolean
+
 	    /** Indicates whether or not to block access to Privacy in Settings app. */
-		        settingsBlockPrivacyPage: boolean
-	
+		settingsBlockPrivacyPage?: boolean
+
 	    /** Indicates whether or not to block access to Update & Security in Settings app. */
-		        settingsBlockUpdateSecurityPage: boolean
-	
+		settingsBlockUpdateSecurityPage?: boolean
+
 	    /** Indicates whether or not to block access to Apps in Settings app. */
-		        settingsBlockAppsPage: boolean
-	
+		settingsBlockAppsPage?: boolean
+
 	    /** Indicates whether or not to block access to Gaming in Settings app. */
-		        settingsBlockGamingPage: boolean
-	
+		settingsBlockGamingPage?: boolean
+
 	    /** Allows IT admins to block experiences that are typically for consumers only, such as Start suggestions, Membership notifications, Post-OOBE app install and redirect tiles. */
-		        windowsSpotlightBlockConsumerSpecificFeatures: boolean
-	
+		windowsSpotlightBlockConsumerSpecificFeatures?: boolean
+
 	    /** Allows IT admins to turn off all Windows Spotlight features */
-		        windowsSpotlightBlocked: boolean
-	
+		windowsSpotlightBlocked?: boolean
+
 	    /** Block suggestions from Microsoft that show after each OS clean install, upgrade or in an on-going basis to introduce users to what is new or changed */
-		        windowsSpotlightBlockOnActionCenter: boolean
-	
-	    /** Block personalized content in Windows spotlight based on user’s device usage. */
-		        windowsSpotlightBlockTailoredExperiences: boolean
-	
+		windowsSpotlightBlockOnActionCenter?: boolean
+
+	    /** Block personalized content in Windows spotlight based on user's device usage. */
+		windowsSpotlightBlockTailoredExperiences?: boolean
+
 	    /** Block third party content delivered via Windows Spotlight */
-		        windowsSpotlightBlockThirdPartyNotifications: boolean
-	
+		windowsSpotlightBlockThirdPartyNotifications?: boolean
+
 	    /** Block Windows Spotlight Windows welcome experience */
-		        windowsSpotlightBlockWelcomeExperience: boolean
-	
+		windowsSpotlightBlockWelcomeExperience?: boolean
+
 	    /** Allows IT admins to turn off the popup of Windows Tips. */
-		        windowsSpotlightBlockWindowsTips: boolean
-	
+		windowsSpotlightBlockWindowsTips?: boolean
+
 	    /** Specifies the type of Spotlight. Possible values are: notConfigured, disabled, enabled. */
-		        windowsSpotlightConfigureOnLockScreen: WindowsSpotlightEnablementSettings
-	
-	    /** If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account that’s enrolled into MDM. */
-		        networkProxyApplySettingsDeviceWide: boolean
-	
+		windowsSpotlightConfigureOnLockScreen?: WindowsSpotlightEnablementSettings
+
+	    /** If set, proxy settings will be applied to all processes and accounts in the device. Otherwise, it will be applied to the user account that's enrolled into MDM. */
+		networkProxyApplySettingsDeviceWide?: boolean
+
 	    /** Disable automatic detection of settings. If enabled, the system will try to find the path to a proxy auto-config (PAC) script. */
-		        networkProxyDisableAutoDetect: boolean
-	
+		networkProxyDisableAutoDetect?: boolean
+
 	    /** Address to the proxy auto-config (PAC) script you want to use. */
-		        networkProxyAutomaticConfigurationUrl?: string
-	
+		networkProxyAutomaticConfigurationUrl?: string
+
 	    /** Specifies manual proxy server settings. */
-		        networkProxyServer?: Windows10NetworkProxyServer
-	
+		networkProxyServer?: Windows10NetworkProxyServer
+
 	    /** Indicates whether or not to Block the user from adding email accounts to the device that are not associated with a Microsoft account. */
-		        accountsBlockAddingNonMicrosoftAccountEmail: boolean
-	
+		accountsBlockAddingNonMicrosoftAccountEmail?: boolean
+
 	    /** Indicates whether or not to block the user from selecting an AntiTheft mode preference (Windows 10 Mobile only). */
-		        antiTheftModeBlocked: boolean
-	
+		antiTheftModeBlocked?: boolean
+
 	    /** Whether or not to Block the user from using bluetooth. */
-		        bluetoothBlocked: boolean
-	
+		bluetoothBlocked?: boolean
+
 	    /** Whether or not to Block the user from accessing the camera of the device. */
-		        cameraBlocked: boolean
-	
+		cameraBlocked?: boolean
+
 	    /** Whether or not to block Connected Devices Service which enables discovery and connection to other devices, remote messaging, remote app sessions and other cross-device experiences. */
-		        connectedDevicesServiceBlocked: boolean
-	
+		connectedDevicesServiceBlocked?: boolean
+
 	    /** Whether or not to Block the user from doing manual root certificate installation. */
-		        certificatesBlockManualRootCertificateInstallation: boolean
-	
+		certificatesBlockManualRootCertificateInstallation?: boolean
+
 	    /** Whether or not to Block the user from using copy paste. */
-		        copyPasteBlocked: boolean
-	
+		copyPasteBlocked?: boolean
+
 	    /** Whether or not to Block the user from using Cortana. */
-		        cortanaBlocked: boolean
-	
+		cortanaBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from resetting their phone. */
-		        deviceManagementBlockFactoryResetOnMobile: boolean
-	
+		deviceManagementBlockFactoryResetOnMobile?: boolean
+
 	    /** Indicates whether or not to Block the user from doing manual un-enrollment from device management. */
-		        deviceManagementBlockManualUnenroll: boolean
-	
+		deviceManagementBlockManualUnenroll?: boolean
+
 	    /** Specifies what filter level of safe search is required. Possible values are: userDefined, strict, moderate. */
-		        safeSearchFilter: SafeSearchFilterType
-	
+		safeSearchFilter?: SafeSearchFilterType
+
 	    /** Indicates whether or not to block popups. */
-		        edgeBlockPopups: boolean
-	
+		edgeBlockPopups?: boolean
+
 	    /** Indicates whether or not to Block the user from using the search suggestions in the address bar. */
-		        edgeBlockSearchSuggestions: boolean
-	
+		edgeBlockSearchSuggestions?: boolean
+
 	    /** Indicates whether or not to Block the user from sending Intranet traffic to Internet Explorer from Microsoft Edge. */
-		        edgeBlockSendingIntranetTrafficToInternetExplorer: boolean
-	
+		edgeBlockSendingIntranetTrafficToInternetExplorer?: boolean
+
 	    /** Indicates whether or not to Require the user to use the smart screen filter. */
-		        edgeRequireSmartScreen: boolean
-	
+		edgeRequireSmartScreen?: boolean
+
 	    /** Indicates the enterprise mode site list location. Could be a local file, local network or http location. */
-		        edgeEnterpriseModeSiteListLocation?: string
-	
+		edgeEnterpriseModeSiteListLocation?: string
+
 	    /** The first run URL for when Microsoft Edge browser is opened for the first time. */
-		        edgeFirstRunUrl?: string
-	
+		edgeFirstRunUrl?: string
+
 	    /** Allows IT admins to set a default search engine for MDM-Controlled devices. Users can override this and change their default search engine provided the AllowSearchEngineCustomization policy is not set. */
-		        edgeSearchEngine?: EdgeSearchEngineBase
-	
+		edgeSearchEngine?: EdgeSearchEngineBase
+
 	    /** The list of URLs for homepages shodwn on MDM-enrolled devices on Microsoft Edge browser. */
-		        edgeHomepageUrls?: string[]
-	
+		edgeHomepageUrls?: string[]
+
 	    /** Indicates whether or not to prevent access to about flags on Microsoft Edge browser. */
-		        edgeBlockAccessToAboutFlags: boolean
-	
+		edgeBlockAccessToAboutFlags?: boolean
+
 	    /** Indicates whether or not users can override SmartScreen Filter warnings about potentially malicious websites. */
-		        smartScreenBlockPromptOverride: boolean
-	
+		smartScreenBlockPromptOverride?: boolean
+
 	    /** Indicates whether or not users can override the SmartScreen Filter warnings about downloading unverified files */
-		        smartScreenBlockPromptOverrideForFiles: boolean
-	
+		smartScreenBlockPromptOverrideForFiles?: boolean
+
 	    /** Indicates whether or not user's localhost IP address is displayed while making phone calls using the WebRTC */
-		        webRtcBlockLocalhostIpAddress: boolean
-	
+		webRtcBlockLocalhostIpAddress?: boolean
+
 	    /** Indicates whether or not to Block the user from using internet sharing. */
-		        internetSharingBlocked: boolean
-	
+		internetSharingBlocked?: boolean
+
 	    /** Indicates whether or not to block the user from installing provisioning packages. */
-		        settingsBlockAddProvisioningPackage: boolean
-	
+		settingsBlockAddProvisioningPackage?: boolean
+
 	    /** Indicates whether or not to block the runtime configuration agent from removing provisioning packages. */
-		        settingsBlockRemoveProvisioningPackage: boolean
-	
+		settingsBlockRemoveProvisioningPackage?: boolean
+
 	    /** Indicates whether or not to block the user from changing date and time settings. */
-		        settingsBlockChangeSystemTime: boolean
-	
+		settingsBlockChangeSystemTime?: boolean
+
 	    /** Indicates whether or not to block the user from editing the device name. */
-		        settingsBlockEditDeviceName: boolean
-	
+		settingsBlockEditDeviceName?: boolean
+
 	    /** Indicates whether or not to block the user from changing the region settings. */
-		        settingsBlockChangeRegion: boolean
-	
+		settingsBlockChangeRegion?: boolean
+
 	    /** Indicates whether or not to block the user from changing the language settings. */
-		        settingsBlockChangeLanguage: boolean
-	
+		settingsBlockChangeLanguage?: boolean
+
 	    /** Indicates whether or not to block the user from changing power and sleep settings. */
-		        settingsBlockChangePowerSleep: boolean
-	
+		settingsBlockChangePowerSleep?: boolean
+
 	    /** Indicates whether or not to Block the user from location services. */
-		        locationServicesBlocked: boolean
-	
+		locationServicesBlocked?: boolean
+
 	    /** Indicates whether or not to Block a Microsoft account. */
-		        microsoftAccountBlocked: boolean
-	
+		microsoftAccountBlocked?: boolean
+
 	    /** Indicates whether or not to Block Microsoft account settings sync. */
-		        microsoftAccountBlockSettingsSync: boolean
-	
+		microsoftAccountBlockSettingsSync?: boolean
+
 	    /** Indicates whether or not to Block the user from using near field communication. */
-		        nfcBlocked: boolean
-	
+		nfcBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from reset protection mode. */
-		        resetProtectionModeBlocked: boolean
-	
+		resetProtectionModeBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from taking Screenshots. */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from using removable storage. */
-		        storageBlockRemovableStorage: boolean
-	
+		storageBlockRemovableStorage?: boolean
+
 	    /** Indicating whether or not to require encryption on a mobile device. */
-		        storageRequireMobileDeviceEncryption: boolean
-	
+		storageRequireMobileDeviceEncryption?: boolean
+
 	    /** Indicates whether or not to Block the user from USB connection. */
-		        usbBlocked: boolean
-	
+		usbBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from voice recording. */
-		        voiceRecordingBlocked: boolean
-	
+		voiceRecordingBlocked?: boolean
+
 	    /** Indicating whether or not to block automatically connecting to Wi-Fi hotspots. Has no impact if Wi-Fi is blocked. */
-		        wiFiBlockAutomaticConnectHotspots: boolean
-	
+		wiFiBlockAutomaticConnectHotspots?: boolean
+
 	    /** Indicates whether or not to Block the user from using Wi-Fi. */
-		        wiFiBlocked: boolean
-	
+		wiFiBlocked?: boolean
+
 	    /** Indicates whether or not to Block the user from using Wi-Fi manual configuration. */
-		        wiFiBlockManualConfiguration: boolean
-	
+		wiFiBlockManualConfiguration?: boolean
+
 	    /** Specify how often devices scan for Wi-Fi networks. Supported values are 1-500, where 100 = default, and 500 = low frequency. Valid values 1 to 500 */
-		        wiFiScanInterval?: number
-	
+		wiFiScanInterval?: number
+
 	    /** Indicates whether or not to allow other devices from discovering this PC for projection. */
-		        wirelessDisplayBlockProjectionToThisDevice: boolean
-	
+		wirelessDisplayBlockProjectionToThisDevice?: boolean
+
 	    /** Indicates whether or not to allow user input from wireless display receiver. */
-		        wirelessDisplayBlockUserInputFromReceiver: boolean
-	
+		wirelessDisplayBlockUserInputFromReceiver?: boolean
+
 	    /** Indicates whether or not to require a PIN for new devices to initiate pairing. */
-		        wirelessDisplayRequirePinForPairing: boolean
-	
+		wirelessDisplayRequirePinForPairing?: boolean
+
 	    /** Indicates whether or not to Block the user from using the Windows store. */
-		        windowsStoreBlocked: boolean
-	
+		windowsStoreBlocked?: boolean
+
 	    /** Indicates whether apps from AppX packages signed with a trusted certificate can be side loaded. Possible values are: notConfigured, blocked, allowed. */
-		        appsAllowTrustedAppsSideloading: StateManagementSetting
-	
+		appsAllowTrustedAppsSideloading?: StateManagementSetting
+
 	    /** Indicates whether or not to block automatic update of apps from Windows Store. */
-		        windowsStoreBlockAutoUpdate: boolean
-	
+		windowsStoreBlockAutoUpdate?: boolean
+
 	    /** Indicates whether or not to allow developer unlock. Possible values are: notConfigured, blocked, allowed. */
-		        developerUnlockSetting: StateManagementSetting
-	
+		developerUnlockSetting?: StateManagementSetting
+
 	    /** Indicates whether or not to block multiple users of the same app to share data. */
-		        sharedUserAppDataAllowed: boolean
-	
+		sharedUserAppDataAllowed?: boolean
+
 	    /** Indicates whether or not to disable the launch of all apps from Windows Store that came pre-installed or were downloaded. */
-		        appsBlockWindowsStoreOriginatedApps: boolean
-	
+		appsBlockWindowsStoreOriginatedApps?: boolean
+
 	    /** Indicates whether or not to enable Private Store Only. */
-		        windowsStoreEnablePrivateStoreOnly: boolean
-	
+		windowsStoreEnablePrivateStoreOnly?: boolean
+
 	    /** Indicates whether application data is restricted to the system drive. */
-		        storageRestrictAppDataToSystemVolume: boolean
-	
+		storageRestrictAppDataToSystemVolume?: boolean
+
 	    /** Indicates whether the installation of applications is restricted to the system drive. */
-		        storageRestrictAppInstallToSystemVolume: boolean
-	
+		storageRestrictAppInstallToSystemVolume?: boolean
+
 	    /** Indicates whether or not to block DVR and broadcasting. */
-		        gameDvrBlocked: boolean
-	
+		gameDvrBlocked?: boolean
+
 	    /** Indicates whether or not to enable device discovery UX. */
-		        experienceBlockDeviceDiscovery: boolean
-	
+		experienceBlockDeviceDiscovery?: boolean
+
 	    /** Indicates whether or not to allow the error dialog from displaying if no SIM card is detected. */
-		        experienceBlockErrorDialogWhenNoSIM: boolean
-	
+		experienceBlockErrorDialogWhenNoSIM?: boolean
+
 	    /** Indicates whether or not to enable task switching on the device. */
-		        experienceBlockTaskSwitcher: boolean
-	
+		experienceBlockTaskSwitcher?: boolean
+
 	    /** Disables the ability to quickly switch between users that are logged on simultaneously without logging off. */
-		        logonBlockFastUserSwitching: boolean
-	
+		logonBlockFastUserSwitching?: boolean
+
 }
 
 export interface Windows10CustomConfiguration extends DeviceConfiguration {
 
 	    /** OMA settings. This collection can contain a maximum of 1000 elements. */
-		        omaSettings?: OmaSetting[]
-	
+		omaSettings?: OmaSetting[]
+
 }
 
 export interface Windows10EnterpriseModernAppManagementConfiguration extends DeviceConfiguration {
 
 	    /** Indicates whether or not to uninstall a fixed list of built-in Windows apps. */
-		        uninstallBuiltInApps: boolean
-	
+		uninstallBuiltInApps?: boolean
+
 }
 
 export interface SharedPCConfiguration extends DeviceConfiguration {
 
 	    /** Specifies how accounts are managed on a shared PC. Only applies when disableAccountManager is false. */
-		        accountManagerPolicy?: SharedPCAccountManagerPolicy
-	
+		accountManagerPolicy?: SharedPCAccountManagerPolicy
+
 	    /** Indicates which type of accounts are allowed to use on a shared PC. Possible values are: guest, domain. */
-		        allowedAccounts: SharedPCAllowedAccountType
-	
+		allowedAccounts?: SharedPCAllowedAccountType
+
 	    /** Specifies whether local storage is allowed on a shared PC. */
-		        allowLocalStorage: boolean
-	
+		allowLocalStorage?: boolean
+
 	    /** Disables the account manager for shared PC mode. */
-		        disableAccountManager: boolean
-	
+		disableAccountManager?: boolean
+
 	    /** Specifies whether the default shared PC education environment policies should be disabled. For Windows 10 RS2 and later, this policy will be applied without setting Enabled to true. */
-		        disableEduPolicies: boolean
-	
+		disableEduPolicies?: boolean
+
 	    /** Specifies whether the default shared PC power policies should be disabled. */
-		        disablePowerPolicies: boolean
-	
+		disablePowerPolicies?: boolean
+
 	    /** Disables the requirement to sign in whenever the device wakes up from sleep mode. */
-		        disableSignInOnResume: boolean
-	
+		disableSignInOnResume?: boolean
+
 	    /** Enables shared PC mode and applies the shared pc policies. */
-		        enabled: boolean
-	
+		enabled?: boolean
+
 	    /** Specifies the time in seconds that a device must sit idle before the PC goes to sleep. Setting this value to 0 prevents the sleep timeout from occurring. */
-		        idleTimeBeforeSleepInSeconds?: number
-	
+		idleTimeBeforeSleepInSeconds?: number
+
 	    /** Specifies the display text for the account shown on the sign-in screen which launches the app specified by SetKioskAppUserModelId. Only applies when KioskAppUserModelId is set. */
-		        kioskAppDisplayName?: string
-	
+		kioskAppDisplayName?: string
+
 	    /** Specifies the application user model ID of the app to use with assigned access. */
-		        kioskAppUserModelId?: string
-	
+		kioskAppUserModelId?: string
+
 	    /** Specifies the daily start time of maintenance hour. */
-		        maintenanceStartTime?: string
-	
+		maintenanceStartTime?: string
+
 }
 
 export interface Windows10SecureAssessmentConfiguration extends DeviceConfiguration {
 
 	    /** Url link to an assessment that's automatically loaded when the secure assessment browser is launched. It has to be a valid Url (http[s]://msdn.microsoft.com/). */
-		        launchUri?: string
-	
+		launchUri?: string
+
 	    /** The account used to configure the Windows device for taking the test. The user can be a domain account (domain\user), an AAD account (username@tenant.com) or a local account (username). */
-		        configurationAccount?: string
-	
+		configurationAccount?: string
+
 	    /** Indicates whether or not to allow the app from printing during the test. */
-		        allowPrinting: boolean
-	
+		allowPrinting?: boolean
+
 	    /** Indicates whether or not to allow screen capture capability during a test. */
-		        allowScreenCapture: boolean
-	
+		allowScreenCapture?: boolean
+
 	    /** Indicates whether or not to allow text suggestions during the test. */
-		        allowTextSuggestion: boolean
-	
+		allowTextSuggestion?: boolean
+
 }
 
 export interface WindowsPhone81CustomConfiguration extends DeviceConfiguration {
 
 	    /** OMA settings. This collection can contain a maximum of 1000 elements. */
-		        omaSettings?: OmaSetting[]
-	
+		omaSettings?: OmaSetting[]
+
 }
 
 export interface WindowsUpdateForBusinessConfiguration extends DeviceConfiguration {
 
 	    /** Delivery Optimization Mode. Possible values are: userDefined, httpOnly, httpWithPeeringNat, httpWithPeeringPrivateGroup, httpWithInternetPeering, simpleDownload, bypassMode. */
-		        deliveryOptimizationMode: WindowsDeliveryOptimizationMode
-	
+		deliveryOptimizationMode?: WindowsDeliveryOptimizationMode
+
 	    /** The pre-release features. Possible values are: userDefined, settingsOnly, settingsAndExperimentations, notAllowed. */
-		        prereleaseFeatures: PrereleaseFeatures
-	
+		prereleaseFeatures?: PrereleaseFeatures
+
 	    /** Automatic update mode. Possible values are: userDefined, notifyDownload, autoInstallAtMaintenanceTime, autoInstallAndRebootAtMaintenanceTime, autoInstallAndRebootAtScheduledTime, autoInstallAndRebootWithoutEndUserControl. */
-		        automaticUpdateMode: AutomaticUpdateMode
-	
+		automaticUpdateMode?: AutomaticUpdateMode
+
 	    /** Allow Microsoft Update Service */
-		        microsoftUpdateServiceAllowed: boolean
-	
+		microsoftUpdateServiceAllowed?: boolean
+
 	    /** Exclude Windows update Drivers */
-		        driversExcluded: boolean
-	
+		driversExcluded?: boolean
+
 	    /** Installation schedule */
-		        installationSchedule?: WindowsUpdateInstallScheduleType
-	
+		installationSchedule?: WindowsUpdateInstallScheduleType
+
 	    /** Defer Quality Updates by these many days */
-		        qualityUpdatesDeferralPeriodInDays: number
-	
+		qualityUpdatesDeferralPeriodInDays?: number
+
 	    /** Defer Feature Updates by these many days */
-		        featureUpdatesDeferralPeriodInDays: number
-	
+		featureUpdatesDeferralPeriodInDays?: number
+
 	    /** Pause Quality Updates */
-		        qualityUpdatesPaused: boolean
-	
+		qualityUpdatesPaused?: boolean
+
 	    /** Pause Feature Updates */
-		        featureUpdatesPaused: boolean
-	
+		featureUpdatesPaused?: boolean
+
 	    /** Quality Updates Pause Expiry datetime */
-		        qualityUpdatesPauseExpiryDateTime: string
-	
+		qualityUpdatesPauseExpiryDateTime?: string
+
 	    /** Feature Updates Pause Expiry datetime */
-		        featureUpdatesPauseExpiryDateTime: string
-	
+		featureUpdatesPauseExpiryDateTime?: string
+
 	    /** Determines which branch devices will receive their updates from. Possible values are: userDefined, all, businessReadyOnly. */
-		        businessReadyUpdatesOnly: WindowsUpdateType
-	
+		businessReadyUpdatesOnly?: WindowsUpdateType
+
 }
 
 export interface Windows81GeneralConfiguration extends DeviceConfiguration {
 
 	    /** Indicates whether or not to Block the user from adding email accounts to the device that are not associated with a Microsoft account. */
-		        accountsBlockAddingNonMicrosoftAccountEmail: boolean
-	
+		accountsBlockAddingNonMicrosoftAccountEmail?: boolean
+
 	    /** Value indicating whether this policy only applies to Windows 8.1. This property is read-only. */
-		        applyOnlyToWindows81: boolean
-	
+		applyOnlyToWindows81?: boolean
+
 	    /** Indicates whether or not to block auto fill. */
-		        browserBlockAutofill: boolean
-	
+		browserBlockAutofill?: boolean
+
 	    /** Indicates whether or not to block automatic detection of Intranet sites. */
-		        browserBlockAutomaticDetectionOfIntranetSites: boolean
-	
+		browserBlockAutomaticDetectionOfIntranetSites?: boolean
+
 	    /** Indicates whether or not to block enterprise mode access. */
-		        browserBlockEnterpriseModeAccess: boolean
-	
+		browserBlockEnterpriseModeAccess?: boolean
+
 	    /** Indicates whether or not to Block the user from using JavaScript. */
-		        browserBlockJavaScript: boolean
-	
+		browserBlockJavaScript?: boolean
+
 	    /** Indicates whether or not to block plug-ins. */
-		        browserBlockPlugins: boolean
-	
+		browserBlockPlugins?: boolean
+
 	    /** Indicates whether or not to block popups. */
-		        browserBlockPopups: boolean
-	
+		browserBlockPopups?: boolean
+
 	    /** Indicates whether or not to Block the user from sending the do not track header. */
-		        browserBlockSendingDoNotTrackHeader: boolean
-	
+		browserBlockSendingDoNotTrackHeader?: boolean
+
 	    /** Indicates whether or not to block a single word entry on Intranet sites. */
-		        browserBlockSingleWordEntryOnIntranetSites: boolean
-	
+		browserBlockSingleWordEntryOnIntranetSites?: boolean
+
 	    /** Indicates whether or not to require the user to use the smart screen filter. */
-		        browserRequireSmartScreen: boolean
-	
+		browserRequireSmartScreen?: boolean
+
 	    /** The enterprise mode site list location. Could be a local file, local network or http location. */
-		        browserEnterpriseModeSiteListLocation?: string
-	
+		browserEnterpriseModeSiteListLocation?: string
+
 	    /** The internet security level. Possible values are: userDefined, medium, mediumHigh, high. */
-		        browserInternetSecurityLevel: InternetSiteSecurityLevel
-	
+		browserInternetSecurityLevel?: InternetSiteSecurityLevel
+
 	    /** The Intranet security level. Possible values are: userDefined, low, mediumLow, medium, mediumHigh, high. */
-		        browserIntranetSecurityLevel: SiteSecurityLevel
-	
+		browserIntranetSecurityLevel?: SiteSecurityLevel
+
 	    /** The logging report location. */
-		        browserLoggingReportLocation?: string
-	
+		browserLoggingReportLocation?: string
+
 	    /** Indicates whether or not to require high security for restricted sites. */
-		        browserRequireHighSecurityForRestrictedSites: boolean
-	
+		browserRequireHighSecurityForRestrictedSites?: boolean
+
 	    /** Indicates whether or not to require a firewall. */
-		        browserRequireFirewall: boolean
-	
+		browserRequireFirewall?: boolean
+
 	    /** Indicates whether or not to require fraud warning. */
-		        browserRequireFraudWarning: boolean
-	
+		browserRequireFraudWarning?: boolean
+
 	    /** The trusted sites security level. Possible values are: userDefined, low, mediumLow, medium, mediumHigh, high. */
-		        browserTrustedSitesSecurityLevel: SiteSecurityLevel
-	
+		browserTrustedSitesSecurityLevel?: SiteSecurityLevel
+
 	    /** Indicates whether or not to block data roaming. */
-		        cellularBlockDataRoaming: boolean
-	
+		cellularBlockDataRoaming?: boolean
+
 	    /** Indicates whether or not to block diagnostic data submission. */
-		        diagnosticsBlockDataSubmission: boolean
-	
+		diagnosticsBlockDataSubmission?: boolean
+
 	    /** Indicates whether or not to Block the user from using a pictures password and pin. */
-		        passwordBlockPicturePasswordAndPin: boolean
-	
+		passwordBlockPicturePasswordAndPin?: boolean
+
 	    /** Password expiration in days. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** The minimum password length. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** The minutes of inactivity before the screen times out. */
-		        passwordMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The number of previous passwords to prevent re-use of. Valid values 0 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** The number of sign in failures before factory reset. */
-		        passwordSignInFailureCountBeforeFactoryReset?: number
-	
+		passwordSignInFailureCountBeforeFactoryReset?: number
+
 	    /** Indicates whether or not to require encryption on a mobile device. */
-		        storageRequireDeviceEncryption: boolean
-	
+		storageRequireDeviceEncryption?: boolean
+
 	    /** Indicates whether or not to require automatic updates. */
-		        updatesRequireAutomaticUpdates: boolean
-	
+		updatesRequireAutomaticUpdates?: boolean
+
 	    /** The user account control settings. Possible values are: userDefined, alwaysNotify, notifyOnAppChanges, notifyOnAppChangesWithoutDimming, neverNotify. */
-		        userAccountControlSettings: WindowsUserAccountControlSettings
-	
+		userAccountControlSettings?: WindowsUserAccountControlSettings
+
 	    /** The work folders url. */
-		        workFoldersUrl?: string
-	
+		workFoldersUrl?: string
+
 }
 
 export interface WindowsPhone81GeneralConfiguration extends DeviceConfiguration {
 
 	    /** Value indicating whether this policy only applies to Windows Phone 8.1. This property is read-only. */
-		        applyOnlyToWindowsPhone81: boolean
-	
+		applyOnlyToWindowsPhone81?: boolean
+
 	    /** Indicates whether or not to block copy paste. */
-		        appsBlockCopyPaste: boolean
-	
+		appsBlockCopyPaste?: boolean
+
 	    /** Indicates whether or not to block bluetooth. */
-		        bluetoothBlocked: boolean
-	
+		bluetoothBlocked?: boolean
+
 	    /** Indicates whether or not to block camera. */
-		        cameraBlocked: boolean
-	
+		cameraBlocked?: boolean
+
 	    /** Indicates whether or not to block Wi-Fi tethering. Has no impact if Wi-Fi is blocked. */
-		        cellularBlockWifiTethering: boolean
-	
+		cellularBlockWifiTethering?: boolean
+
 	    /** List of apps in the compliance (either allow list or block list, controlled by CompliantAppListType). This collection can contain a maximum of 10000 elements. */
-		        compliantAppsList?: AppListItem[]
-	
+		compliantAppsList?: AppListItem[]
+
 	    /** List that is in the AppComplianceList. Possible values are: none, appsInListCompliant, appsNotInListCompliant. */
-		        compliantAppListType: AppListType
-	
+		compliantAppListType?: AppListType
+
 	    /** Indicates whether or not to block diagnostic data submission. */
-		        diagnosticDataBlockSubmission: boolean
-	
+		diagnosticDataBlockSubmission?: boolean
+
 	    /** Indicates whether or not to block custom email accounts. */
-		        emailBlockAddingAccounts: boolean
-	
+		emailBlockAddingAccounts?: boolean
+
 	    /** Indicates whether or not to block location services. */
-		        locationServicesBlocked: boolean
-	
+		locationServicesBlocked?: boolean
+
 	    /** Indicates whether or not to block using a Microsoft Account. */
-		        microsoftAccountBlocked: boolean
-	
+		microsoftAccountBlocked?: boolean
+
 	    /** Indicates whether or not to block Near-Field Communication. */
-		        nfcBlocked: boolean
-	
+		nfcBlocked?: boolean
+
 	    /** Indicates whether or not to block syncing the calendar. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Number of days before the password expires. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Minimum length of passwords. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity before screen timeout. */
-		        passwordMinutesOfInactivityBeforeScreenTimeout?: number
-	
+		passwordMinutesOfInactivityBeforeScreenTimeout?: number
+
 	    /** Number of character sets a password must contain. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** Number of previous passwords to block. Valid values 0 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Number of sign in failures allowed before factory reset. */
-		        passwordSignInFailureCountBeforeFactoryReset?: number
-	
+		passwordSignInFailureCountBeforeFactoryReset?: number
+
 	    /** Password type that is required. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** Indicates whether or not to require a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to block screenshots. */
-		        screenCaptureBlocked: boolean
-	
+		screenCaptureBlocked?: boolean
+
 	    /** Indicates whether or not to block removable storage. */
-		        storageBlockRemovableStorage: boolean
-	
+		storageBlockRemovableStorage?: boolean
+
 	    /** Indicates whether or not to require encryption. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 	    /** Indicates whether or not to block the web browser. */
-		        webBrowserBlocked: boolean
-	
+		webBrowserBlocked?: boolean
+
 	    /** Indicates whether or not to block Wi-Fi. */
-		        wifiBlocked: boolean
-	
+		wifiBlocked?: boolean
+
 	    /** Indicates whether or not to block automatically connecting to Wi-Fi hotspots. Has no impact if Wi-Fi is blocked. */
-		        wifiBlockAutomaticConnectHotspots: boolean
-	
+		wifiBlockAutomaticConnectHotspots?: boolean
+
 	    /** Indicates whether or not to block Wi-Fi hotspot reporting. Has no impact if Wi-Fi is blocked. */
-		        wifiBlockHotspotReporting: boolean
-	
+		wifiBlockHotspotReporting?: boolean
+
 	    /** Indicates whether or not to block the Windows Store. */
-		        windowsStoreBlocked: boolean
-	
+		windowsStoreBlocked?: boolean
+
 }
 
 export interface Windows10TeamGeneralConfiguration extends DeviceConfiguration {
 
 	    /** Indicates whether or not to Block Azure Operational Insights. */
-		        azureOperationalInsightsBlockTelemetry: boolean
-	
+		azureOperationalInsightsBlockTelemetry?: boolean
+
 	    /** The Azure Operational Insights workspace id. */
-		        azureOperationalInsightsWorkspaceId?: string
-	
+		azureOperationalInsightsWorkspaceId?: string
+
 	    /** The Azure Operational Insights Workspace key. */
-		        azureOperationalInsightsWorkspaceKey?: string
-	
+		azureOperationalInsightsWorkspaceKey?: string
+
 	    /** Specifies whether to automatically launch the Connect app whenever a projection is initiated. */
-		        connectAppBlockAutoLaunch: boolean
-	
+		connectAppBlockAutoLaunch?: boolean
+
 	    /** Indicates whether or not to Block setting a maintenance window for device updates. */
-		        maintenanceWindowBlocked: boolean
-	
+		maintenanceWindowBlocked?: boolean
+
 	    /** Maintenance window duration for device updates. Valid values 0 to 5 */
-		        maintenanceWindowDurationInHours?: number
-	
+		maintenanceWindowDurationInHours?: number
+
 	    /** Maintenance window start time for device updates. */
-		        maintenanceWindowStartTime?: string
-	
+		maintenanceWindowStartTime?: string
+
 	    /** The channel. Possible values are: userDefined, one, two, three, four, five, six, seven, eight, nine, ten, eleven, thirtySix, forty, fortyFour, fortyEight, oneHundredFortyNine, oneHundredFiftyThree, oneHundredFiftySeven, oneHundredSixtyOne, oneHundredSixtyFive. */
-		        miracastChannel: MiracastChannel
-	
+		miracastChannel?: MiracastChannel
+
 	    /** Indicates whether or not to Block wireless projection. */
-		        miracastBlocked: boolean
-	
+		miracastBlocked?: boolean
+
 	    /** Indicates whether or not to require a pin for wireless projection. */
-		        miracastRequirePin: boolean
-	
+		miracastRequirePin?: boolean
+
 	    /** Specifies whether to disable the "My meetings and files" feature in the Start menu, which shows the signed-in user's meetings and files from Office 365. */
-		        settingsBlockMyMeetingsAndFiles: boolean
-	
+		settingsBlockMyMeetingsAndFiles?: boolean
+
 	    /** Specifies whether to allow the ability to resume a session when the session times out. */
-		        settingsBlockSessionResume: boolean
-	
+		settingsBlockSessionResume?: boolean
+
 	    /** Specifies whether to disable auto-populating of the sign-in dialog with invitees from scheduled meetings. */
-		        settingsBlockSigninSuggestions: boolean
-	
+		settingsBlockSigninSuggestions?: boolean
+
 	    /** Specifies the default volume value for a new session. Permitted values are 0-100. The default is 45. Valid values 0 to 100 */
-		        settingsDefaultVolume?: number
-	
+		settingsDefaultVolume?: number
+
 	    /** Specifies the number of minutes until the Hub screen turns off. */
-		        settingsScreenTimeoutInMinutes?: number
-	
+		settingsScreenTimeoutInMinutes?: number
+
 	    /** Specifies the number of minutes until the session times out. */
-		        settingsSessionTimeoutInMinutes?: number
-	
+		settingsSessionTimeoutInMinutes?: number
+
 	    /** Specifies the number of minutes until the Hub enters sleep mode. */
-		        settingsSleepTimeoutInMinutes?: number
-	
+		settingsSleepTimeoutInMinutes?: number
+
 	    /** Indicates whether or not to Block the welcome screen from waking up automatically when someone enters the room. */
-		        welcomeScreenBlockAutomaticWakeUp: boolean
-	
+		welcomeScreenBlockAutomaticWakeUp?: boolean
+
 	    /** The welcome screen background image URL. The URL must use the HTTPS protocol and return a PNG image. */
-		        welcomeScreenBackgroundImageUrl?: string
-	
+		welcomeScreenBackgroundImageUrl?: string
+
 	    /** The welcome screen meeting information shown. Possible values are: userDefined, showOrganizerAndTimeOnly, showOrganizerAndTimeAndSubject. */
-		        welcomeScreenMeetingInformation: WelcomeScreenMeetingInformation
-	
+		welcomeScreenMeetingInformation?: WelcomeScreenMeetingInformation
+
 }
 
 export interface AndroidCompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Require a password to unlock device. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Minimum password length. Valid values 4 to 16 */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Type of characters in password. Possible values are: deviceDefault, alphabetic, alphanumeric, alphanumericWithSymbols, lowSecurityBiometric, numeric, numericComplex, any. */
-		        passwordRequiredType: AndroidRequiredPasswordType
-	
+		passwordRequiredType?: AndroidRequiredPasswordType
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** Number of days before the password expires. Valid values 1 to 365 */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Number of previous passwords to block. */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Require that devices disallow installation of apps from unknown sources. */
-		        securityPreventInstallAppsFromUnknownSources: boolean
-	
+		securityPreventInstallAppsFromUnknownSources?: boolean
+
 	    /** Disable USB debugging on Android devices. */
-		        securityDisableUsbDebugging: boolean
-	
+		securityDisableUsbDebugging?: boolean
+
 	    /** Require the Android Verify apps feature is turned on. */
-		        securityRequireVerifyApps: boolean
-	
+		securityRequireVerifyApps?: boolean
+
 	    /** Require that devices have enabled device threat protection. */
-		        deviceThreatProtectionEnabled: boolean
-	
+		deviceThreatProtectionEnabled?: boolean
+
 	    /** Require Mobile Threat Protection minimum risk level to report noncompliance. Possible values are: unavailable, secured, low, medium, high, notSet. */
-		        deviceThreatProtectionRequiredSecurityLevel: DeviceThreatProtectionLevel
-	
+		deviceThreatProtectionRequiredSecurityLevel?: DeviceThreatProtectionLevel
+
 	    /** Devices must not be jailbroken or rooted. */
-		        securityBlockJailbrokenDevices: boolean
-	
+		securityBlockJailbrokenDevices?: boolean
+
 	    /** Minimum Android version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum Android version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Minimum Android security patch level. */
-		        minAndroidSecurityPatchLevel?: string
-	
+		minAndroidSecurityPatchLevel?: string
+
 	    /** Require encryption on Android devices. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 	    /** Require the device to pass the SafetyNet basic integrity check. */
-		        securityRequireSafetyNetAttestationBasicIntegrity: boolean
-	
+		securityRequireSafetyNetAttestationBasicIntegrity?: boolean
+
 	    /** Require the device to pass the SafetyNet certified device check. */
-		        securityRequireSafetyNetAttestationCertifiedDevice: boolean
-	
+		securityRequireSafetyNetAttestationCertifiedDevice?: boolean
+
 	    /** Require Google Play Services to be installed and enabled on the device. */
-		        securityRequireGooglePlayServices: boolean
-	
+		securityRequireGooglePlayServices?: boolean
+
 	    /** Require the device to have up to date security providers. The device will require Google Play Services to be enabled and up to date. */
-		        securityRequireUpToDateSecurityProviders: boolean
-	
+		securityRequireUpToDateSecurityProviders?: boolean
+
 	    /** Require the device to pass the Company Portal client app runtime integrity check. */
-		        securityRequireCompanyPortalAppIntegrity: boolean
-	
+		securityRequireCompanyPortalAppIntegrity?: boolean
+
+}
+
+export interface AndroidWorkProfileCompliancePolicy extends DeviceCompliancePolicy {
+
+		passwordRequired?: boolean
+
+		passwordMinimumLength?: number
+
+		passwordRequiredType?: AndroidRequiredPasswordType
+
+		passwordMinutesOfInactivityBeforeLock?: number
+
+		passwordExpirationDays?: number
+
+		passwordPreviousPasswordBlockCount?: number
+
+		securityPreventInstallAppsFromUnknownSources?: boolean
+
+		securityDisableUsbDebugging?: boolean
+
+		securityRequireVerifyApps?: boolean
+
+		deviceThreatProtectionEnabled?: boolean
+
+		deviceThreatProtectionRequiredSecurityLevel?: DeviceThreatProtectionLevel
+
+		securityBlockJailbrokenDevices?: boolean
+
+		osMinimumVersion?: string
+
+		osMaximumVersion?: string
+
+		minAndroidSecurityPatchLevel?: string
+
+		storageRequireEncryption?: boolean
+
+		securityRequireSafetyNetAttestationBasicIntegrity?: boolean
+
+		securityRequireSafetyNetAttestationCertifiedDevice?: boolean
+
+		securityRequireGooglePlayServices?: boolean
+
+		securityRequireUpToDateSecurityProviders?: boolean
+
+		securityRequireCompanyPortalAppIntegrity?: boolean
+
 }
 
 export interface IosCompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Indicates whether or not to block simple passcodes. */
-		        passcodeBlockSimple: boolean
-	
+		passcodeBlockSimple?: boolean
+
 	    /** Number of days before the passcode expires. Valid values 1 to 65535 */
-		        passcodeExpirationDays?: number
-	
+		passcodeExpirationDays?: number
+
 	    /** Minimum length of passcode. Valid values 4 to 14 */
-		        passcodeMinimumLength?: number
-	
+		passcodeMinimumLength?: number
+
 	    /** Minutes of inactivity before a passcode is required. */
-		        passcodeMinutesOfInactivityBeforeLock?: number
-	
+		passcodeMinutesOfInactivityBeforeLock?: number
+
 	    /** Number of previous passcodes to block. Valid values 1 to 24 */
-		        passcodePreviousPasscodeBlockCount?: number
-	
+		passcodePreviousPasscodeBlockCount?: number
+
 	    /** The number of character sets required in the password. */
-		        passcodeMinimumCharacterSetCount?: number
-	
+		passcodeMinimumCharacterSetCount?: number
+
 	    /** The required passcode type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passcodeRequiredType: RequiredPasswordType
-	
+		passcodeRequiredType?: RequiredPasswordType
+
 	    /** Indicates whether or not to require a passcode. */
-		        passcodeRequired: boolean
-	
+		passcodeRequired?: boolean
+
 	    /** Minimum IOS version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum IOS version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Devices must not be jailbroken or rooted. */
-		        securityBlockJailbrokenDevices: boolean
-	
+		securityBlockJailbrokenDevices?: boolean
+
 	    /** Require that devices have enabled device threat protection . */
-		        deviceThreatProtectionEnabled: boolean
-	
+		deviceThreatProtectionEnabled?: boolean
+
 	    /** Require Mobile Threat Protection minimum risk level to report noncompliance. Possible values are: unavailable, secured, low, medium, high, notSet. */
-		        deviceThreatProtectionRequiredSecurityLevel: DeviceThreatProtectionLevel
-	
+		deviceThreatProtectionRequiredSecurityLevel?: DeviceThreatProtectionLevel
+
 	    /** Indicates whether or not to require a managed email profile. */
-		        managedEmailProfileRequired: boolean
-	
+		managedEmailProfileRequired?: boolean
+
 }
 
 export interface MacOSCompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Whether or not to require a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to block simple passwords. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Number of days before the password expires. Valid values 1 to 65535 */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Minimum length of password. Valid values 4 to 14 */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** Number of previous passwords to block. Valid values 1 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** Minimum IOS version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum IOS version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Require that devices have enabled system integrity protection. */
-		        systemIntegrityProtectionEnabled: boolean
-	
+		systemIntegrityProtectionEnabled?: boolean
+
 	    /** Require that devices have enabled device threat protection . */
-		        deviceThreatProtectionEnabled: boolean
-	
+		deviceThreatProtectionEnabled?: boolean
+
 	    /** Require Mobile Threat Protection minimum risk level to report noncompliance. Possible values are: unavailable, secured, low, medium, high, notSet. */
-		        deviceThreatProtectionRequiredSecurityLevel: DeviceThreatProtectionLevel
-	
+		deviceThreatProtectionRequiredSecurityLevel?: DeviceThreatProtectionLevel
+
 	    /** Require encryption on Mac OS devices. */
-		        storageRequireEncryption: boolean
-	
-		        firewallEnabled: boolean
-	
-		        firewallBlockAllIncoming: boolean
-	
-		        firewallEnableStealthMode: boolean
-	
+		storageRequireEncryption?: boolean
+
+		firewallEnabled?: boolean
+
+		firewallBlockAllIncoming?: boolean
+
+		firewallEnableStealthMode?: boolean
+
 }
 
 export interface Windows10CompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Require a password to unlock Windows device. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to block simple password. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Require a password to unlock an idle device. */
-		        passwordRequiredToUnlockFromIdle: boolean
-	
+		passwordRequiredToUnlockFromIdle?: boolean
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** The password expiration in days. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** The minimum password length. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** The number of previous passwords to prevent re-use of. */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation. */
-		        requireHealthyDeviceReport: boolean
-	
+		requireHealthyDeviceReport?: boolean
+
 	    /** Minimum Windows 10 version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum Windows 10 version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Minimum Windows Phone version. */
-		        mobileOsMinimumVersion?: string
-	
+		mobileOsMinimumVersion?: string
+
 	    /** Maximum Windows Phone version. */
-		        mobileOsMaximumVersion?: string
-	
+		mobileOsMaximumVersion?: string
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation - early launch antimalware driver is enabled. */
-		        earlyLaunchAntiMalwareDriverEnabled: boolean
-	
+		earlyLaunchAntiMalwareDriverEnabled?: boolean
+
 	    /** Require devices to be reported healthy by Windows Device Health Attestation - bit locker is enabled */
-		        bitLockerEnabled: boolean
-	
+		bitLockerEnabled?: boolean
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation - secure boot is enabled. */
-		        secureBootEnabled: boolean
-	
+		secureBootEnabled?: boolean
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation. */
-		        codeIntegrityEnabled: boolean
-	
+		codeIntegrityEnabled?: boolean
+
 	    /** Require encryption on windows devices. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 }
 
 export interface Windows10MobileCompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Require a password to unlock Windows Phone device. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Whether or not to block syncing the calendar. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Minimum password length. Valid values 4 to 16 */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** The number of previous passwords to prevent re-use of. */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Number of days before password expiration. Valid values 1 to 255 */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** Require a password to unlock an idle device. */
-		        passwordRequireToUnlockFromIdle: boolean
-	
+		passwordRequireToUnlockFromIdle?: boolean
+
 	    /** Minimum Windows Phone version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum Windows Phone version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation - early launch antimalware driver is enabled. */
-		        earlyLaunchAntiMalwareDriverEnabled: boolean
-	
+		earlyLaunchAntiMalwareDriverEnabled?: boolean
+
 	    /** Require devices to be reported healthy by Windows Device Health Attestation - bit locker is enabled */
-		        bitLockerEnabled: boolean
-	
+		bitLockerEnabled?: boolean
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation - secure boot is enabled. */
-		        secureBootEnabled: boolean
-	
+		secureBootEnabled?: boolean
+
 	    /** Require devices to be reported as healthy by Windows Device Health Attestation. */
-		        codeIntegrityEnabled: boolean
-	
+		codeIntegrityEnabled?: boolean
+
 	    /** Require encryption on windows devices. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 }
 
 export interface Windows81CompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Require a password to unlock Windows device. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Indicates whether or not to block simple password. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Password expiration in days. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** The minimum password length. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** The number of previous passwords to prevent re-use of. Valid values 0 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Minimum Windows 8.1 version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum Windows 8.1 version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Indicates whether or not to require encryption on a windows 8.1 device. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 }
 
 export interface WindowsPhone81CompliancePolicy extends DeviceCompliancePolicy {
 
 	    /** Whether or not to block syncing the calendar. */
-		        passwordBlockSimple: boolean
-	
+		passwordBlockSimple?: boolean
+
 	    /** Number of days before the password expires. */
-		        passwordExpirationDays?: number
-	
+		passwordExpirationDays?: number
+
 	    /** Minimum length of passwords. */
-		        passwordMinimumLength?: number
-	
+		passwordMinimumLength?: number
+
 	    /** Minutes of inactivity before a password is required. */
-		        passwordMinutesOfInactivityBeforeLock?: number
-	
+		passwordMinutesOfInactivityBeforeLock?: number
+
 	    /** The number of character sets required in the password. */
-		        passwordMinimumCharacterSetCount?: number
-	
+		passwordMinimumCharacterSetCount?: number
+
 	    /** The required password type. Possible values are: deviceDefault, alphanumeric, numeric. */
-		        passwordRequiredType: RequiredPasswordType
-	
+		passwordRequiredType?: RequiredPasswordType
+
 	    /** Number of previous passwords to block. Valid values 0 to 24 */
-		        passwordPreviousPasswordBlockCount?: number
-	
+		passwordPreviousPasswordBlockCount?: number
+
 	    /** Whether or not to require a password. */
-		        passwordRequired: boolean
-	
+		passwordRequired?: boolean
+
 	    /** Minimum Windows Phone version. */
-		        osMinimumVersion?: string
-	
+		osMinimumVersion?: string
+
 	    /** Maximum Windows Phone version. */
-		        osMaximumVersion?: string
-	
+		osMaximumVersion?: string
+
 	    /** Require encryption on windows phone devices. */
-		        storageRequireEncryption: boolean
-	
+		storageRequireEncryption?: boolean
+
 }
 
 export interface DeviceComplianceSettingState extends Entity {
 
 	    /** The setting class name and property name. */
-		        setting?: string
-	
+		setting?: string
+
 	    /** The Setting Name that is being reported */
-		        settingName?: string
-	
+		settingName?: string
+
 	    /** The Device Id that is being reported */
-		        deviceId?: string
-	
+		deviceId?: string
+
 	    /** The Device Name that is being reported */
-		        deviceName?: string
-	
+		deviceName?: string
+
 	    /** The user Id that is being reported */
-		        userId?: string
-	
+		userId?: string
+
 	    /** The User email address that is being reported */
-		        userEmail?: string
-	
+		userEmail?: string
+
 	    /** The User Name that is being reported */
-		        userName?: string
-	
+		userName?: string
+
 	    /** The User PrincipalName that is being reported */
-		        userPrincipalName?: string
-	
+		userPrincipalName?: string
+
 	    /** The device model that is being reported */
-		        deviceModel?: string
-	
+		deviceModel?: string
+
 	    /** The compliance state of the setting. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-		        state: ComplianceStatus
-	
+		state?: ComplianceStatus
+
 	    /** The DateTime when device compliance grace period expires */
-		        complianceGracePeriodExpirationDateTime: string
-	
+		complianceGracePeriodExpirationDateTime?: string
+
 }
 
 export interface EnrollmentConfigurationAssignment extends Entity {
 
 	    /** Not yet documented */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface DeviceEnrollmentLimitConfiguration extends DeviceEnrollmentConfiguration {
 
 	    /** Not yet documented */
-		        limit: number
-	
+		limit?: number
+
 }
 
 export interface DeviceEnrollmentPlatformRestrictionsConfiguration extends DeviceEnrollmentConfiguration {
 
 	    /** Not yet documented */
-		        iosRestriction?: DeviceEnrollmentPlatformRestriction
-	
+		iosRestriction?: DeviceEnrollmentPlatformRestriction
+
 	    /** Not yet documented */
-		        windowsRestriction?: DeviceEnrollmentPlatformRestriction
-	
+		windowsRestriction?: DeviceEnrollmentPlatformRestriction
+
 	    /** Not yet documented */
-		        windowsMobileRestriction?: DeviceEnrollmentPlatformRestriction
-	
+		windowsMobileRestriction?: DeviceEnrollmentPlatformRestriction
+
 	    /** Not yet documented */
-		        androidRestriction?: DeviceEnrollmentPlatformRestriction
-	
+		androidRestriction?: DeviceEnrollmentPlatformRestriction
+
 	    /** Not yet documented */
-		        macOSRestriction?: DeviceEnrollmentPlatformRestriction
-	
+		macOSRestriction?: DeviceEnrollmentPlatformRestriction
+
 }
 
 export interface DeviceEnrollmentWindowsHelloForBusinessConfiguration extends DeviceEnrollmentConfiguration {
 
 	    /** Not yet documented */
-		        pinMinimumLength: number
-	
+		pinMinimumLength?: number
+
 	    /** Not yet documented */
-		        pinMaximumLength: number
-	
+		pinMaximumLength?: number
+
 	    /** Not yet documented. Possible values are: allowed, required, disallowed. */
-		        pinUppercaseCharactersUsage: WindowsHelloForBusinessPinUsage
-	
+		pinUppercaseCharactersUsage?: WindowsHelloForBusinessPinUsage
+
 	    /** Not yet documented. Possible values are: allowed, required, disallowed. */
-		        pinLowercaseCharactersUsage: WindowsHelloForBusinessPinUsage
-	
+		pinLowercaseCharactersUsage?: WindowsHelloForBusinessPinUsage
+
 	    /** Not yet documented. Possible values are: allowed, required, disallowed. */
-		        pinSpecialCharactersUsage: WindowsHelloForBusinessPinUsage
-	
+		pinSpecialCharactersUsage?: WindowsHelloForBusinessPinUsage
+
 	    /** Not yet documented. Possible values are: notConfigured, enabled, disabled. */
-		        state: Enablement
-	
+		state?: Enablement
+
 	    /** Not yet documented */
-		        securityDeviceRequired: boolean
-	
+		securityDeviceRequired?: boolean
+
 	    /** Not yet documented */
-		        unlockWithBiometricsEnabled: boolean
-	
+		unlockWithBiometricsEnabled?: boolean
+
 	    /** Not yet documented */
-		        remotePassportEnabled: boolean
-	
+		remotePassportEnabled?: boolean
+
 	    /** Not yet documented */
-		        pinPreviousBlockCount: number
-	
+		pinPreviousBlockCount?: number
+
 	    /** Not yet documented */
-		        pinExpirationInDays: number
-	
+		pinExpirationInDays?: number
+
 	    /** Not yet documented. Possible values are: notConfigured, enabled, disabled. */
-		        enhancedBiometricsState: Enablement
-	
+		enhancedBiometricsState?: Enablement
+
 }
 
 export interface ManagedMobileApp extends Entity {
 
 	    /** The identifier for an app with it's operating system type. */
-		        mobileAppIdentifier?: MobileAppIdentifier
-	
+		mobileAppIdentifier?: MobileAppIdentifier
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface TargetedManagedAppPolicyAssignment extends Entity {
 
 	    /** Identifier for deployment of a group or app */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 }
 
 export interface ManagedAppOperation extends Entity {
 
 	    /** The operation name. */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** The last time the app operation was modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The current state of the operation */
-		        state?: string
-	
+		state?: string
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface ManagedAppPolicyDeploymentSummary extends Entity {
 
 	    /** Not yet documented */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** Not yet documented */
-		        configurationDeployedUserCount: number
-	
+		configurationDeployedUserCount?: number
+
 	    /** Not yet documented */
-		        lastRefreshTime: string
-	
+		lastRefreshTime?: string
+
 	    /** Not yet documented */
-		        configurationDeploymentSummaryPerApp?: ManagedAppPolicyDeploymentSummaryPerApp[]
-	
+		configurationDeploymentSummaryPerApp?: ManagedAppPolicyDeploymentSummaryPerApp[]
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface WindowsInformationProtectionAppLockerFile extends Entity {
 
 	    /** The friendly name */
-		        displayName?: string
-	
+		displayName?: string
+
 	    /** SHA256 hash of the file */
-		        fileHash?: string
-	
+		fileHash?: string
+
 	    /** File as a byte array */
-		        file?: number
-	
+		file?: number
+
 	    /** Version of the entity. */
-		        version?: string
-	
+		version?: string
+
 }
 
 export interface IosManagedAppRegistration extends ManagedAppRegistration {
@@ -7803,27 +7982,27 @@ export interface AndroidManagedAppRegistration extends ManagedAppRegistration {
 export interface ManagedAppStatusRaw extends ManagedAppStatus {
 
 	    /** Status report content. */
-		        content?: any
-	
+		content?: any
+
 }
 
 export interface LocalizedNotificationMessage extends Entity {
 
 	    /** DateTime the object was last modified. */
-		        lastModifiedDateTime: string
-	
+		lastModifiedDateTime?: string
+
 	    /** The Locale for which this message is destined. */
-		        locale: string
-	
+		locale?: string
+
 	    /** The Message Template Subject. */
-		        subject: string
-	
+		subject?: string
+
 	    /** The Message Template content. */
-		        messageTemplate: string
-	
+		messageTemplate?: string
+
 	    /** Flag to indicate whether or not this is the default locale for language fallback. This flag can only be set. To unset, set this property to true on another Localized Notification Message. */
-		        isDefault: boolean
-	
+		isDefault?: boolean
+
 }
 
 export interface DeviceAndAppManagementRoleDefinition extends RoleDefinition {
@@ -7833,80 +8012,80 @@ export interface DeviceAndAppManagementRoleDefinition extends RoleDefinition {
 export interface ManagedEBookAssignment extends Entity {
 
 	    /** The assignment target for eBook. */
-		        target?: DeviceAndAppManagementAssignmentTarget
-	
+		target?: DeviceAndAppManagementAssignmentTarget
+
 	    /** The install intent for eBook. Possible values are: available, required, uninstall, availableWithoutEnrollment. */
-		        installIntent: InstallIntent
-	
+		installIntent?: InstallIntent
+
 }
 
 export interface EBookInstallSummary extends Entity {
 
 	    /** Number of Devices that have successfully installed this book. */
-		        installedDeviceCount: number
-	
+		installedDeviceCount?: number
+
 	    /** Number of Devices that have failed to install this book. */
-		        failedDeviceCount: number
-	
+		failedDeviceCount?: number
+
 	    /** Number of Devices that does not have this book installed. */
-		        notInstalledDeviceCount: number
-	
+		notInstalledDeviceCount?: number
+
 	    /** Number of Users whose devices have all succeeded to install this book. */
-		        installedUserCount: number
-	
+		installedUserCount?: number
+
 	    /** Number of Users that have 1 or more device that failed to install this book. */
-		        failedUserCount: number
-	
+		failedUserCount?: number
+
 	    /** Number of Users that did not install this book. */
-		        notInstalledUserCount: number
-	
+		notInstalledUserCount?: number
+
 }
 
 export interface DeviceInstallState extends Entity {
 
 	    /** Device name. */
-		        deviceName?: string
-	
+		deviceName?: string
+
 	    /** Device Id. */
-		        deviceId?: string
-	
+		deviceId?: string
+
 	    /** Last sync date and time. */
-		        lastSyncDateTime: string
-	
+		lastSyncDateTime?: string
+
 	    /** The install state of the eBook. Possible values are: notApplicable, installed, failed, notInstalled, uninstallFailed, unknown. */
-		        installState: InstallState
-	
+		installState?: InstallState
+
 	    /** The error code for install failures. */
-		        errorCode?: string
-	
+		errorCode?: string
+
 	    /** OS Version. */
-		        osVersion?: string
-	
+		osVersion?: string
+
 	    /** OS Description. */
-		        osDescription?: string
-	
+		osDescription?: string
+
 	    /** Device User Name. */
-		        userName?: string
-	
+		userName?: string
+
 }
 
 export interface UserInstallStateSummary extends Entity {
 
 	    /** User name. */
-		        userName?: string
-	
+		userName?: string
+
 	    /** Installed Device Count. */
-		        installedDeviceCount: number
-	
+		installedDeviceCount?: number
+
 	    /** Failed Device Count. */
-		        failedDeviceCount: number
-	
+		failedDeviceCount?: number
+
 	    /** Not installed device count. */
-		        notInstalledDeviceCount: number
-	
+		notInstalledDeviceCount?: number
+
 	    /** The install state of the eBook. */
-		        deviceStates?: DeviceInstallState[]
-	
+		deviceStates?: DeviceInstallState[]
+
 }
 
 export interface IosVppEBookAssignment extends ManagedEBookAssignment {
@@ -7916,289 +8095,447 @@ export interface IosVppEBookAssignment extends ManagedEBookAssignment {
 export interface IosVppEBook extends ManagedEBook {
 
 	    /** The Vpp token ID. */
-		        vppTokenId: string
-	
+		vppTokenId?: string
+
 	    /** The Apple ID associated with Vpp token. */
-		        appleId?: string
-	
+		appleId?: string
+
 	    /** The Vpp token's organization name. */
-		        vppOrganizationName?: string
-	
+		vppOrganizationName?: string
+
 	    /** Genres. */
-		        genres?: string[]
-	
+		genres?: string[]
+
 	    /** Language. */
-		        language?: string
-	
+		language?: string
+
 	    /** Seller. */
-		        seller?: string
-	
+		seller?: string
+
 	    /** Total license count. */
-		        totalLicenseCount: number
-	
+		totalLicenseCount?: number
+
 	    /** Used license count. */
-		        usedLicenseCount: number
-	
+		usedLicenseCount?: number
+
 }
 
 export interface EnrollmentTroubleshootingEvent extends DeviceManagementTroubleshootingEvent {
 
 	    /** Device identifier created or collected by Intune. */
-		        managedDeviceIdentifier?: string
-	
+		managedDeviceIdentifier?: string
+
 	    /** Operating System. */
-		        operatingSystem?: string
-	
+		operatingSystem?: string
+
 	    /** OS Version. */
-		        osVersion?: string
-	
+		osVersion?: string
+
 	    /** Identifier for the user that tried to enroll the device. */
-		        userId?: string
-	
+		userId?: string
+
 	    /** Azure AD device identifier. */
-		        deviceId?: string
-	
+		deviceId?: string
+
 	    /** Type of the enrollment. Possible values are: unknown, userEnrollment, deviceEnrollmentManager, appleBulkWithUser, appleBulkWithoutUser, windowsAzureADJoin, windowsBulkUserless, windowsAutoEnrollment, windowsBulkAzureDomainJoin, windowsCoManagement. */
-		        enrollmentType: DeviceEnrollmentType
-	
+		enrollmentType?: DeviceEnrollmentType
+
 	    /** Highlevel failure category. Possible values are: unknown, authentication, authorization, accountValidation, userValidation, deviceNotSupported, inMaintenance, badRequest, featureNotSupported, enrollmentRestrictionsEnforced, clientDisconnected. */
-		        failureCategory: DeviceEnrollmentFailureReason
-	
+		failureCategory?: DeviceEnrollmentFailureReason
+
 	    /** Detailed failure reason. */
-		        failureReason?: string
-	
+		failureReason?: string
+
 }
 
 export interface ActivityHistoryItem extends Entity {
 
-		        status?: Status
-	
-		        activeDurationSeconds?: number
-	
-		        createdDateTime?: string
-	
-		        lastActiveDateTime?: string
-	
-		        lastModifiedDateTime?: string
-	
-		        expirationDateTime?: string
-	
-		        startedDateTime: string
-	
-		        userTimezone?: string
-	
-		        activity: UserActivity
-	
+		status?: Status
+
+		activeDurationSeconds?: number
+
+		createdDateTime?: string
+
+		lastActiveDateTime?: string
+
+		lastModifiedDateTime?: string
+
+		expirationDateTime?: string
+
+		startedDateTime?: string
+
+		userTimezone?: string
+
+		activity?: UserActivity
+
+}
+
+export interface Security extends Entity {
+
+		alerts?: Alert[]
+
+}
+
+export interface Alert extends Entity {
+
+		activityGroupName?: string
+
+		assignedTo?: string
+
+		azureSubscriptionId?: string
+
+		azureTenantId?: string
+
+		category?: string
+
+		closedDateTime?: string
+
+		cloudAppStates?: CloudAppSecurityState[]
+
+		comments?: string[]
+
+		confidence?: number
+
+		createdDateTime?: string
+
+		description?: string
+
+		detectionIds?: string[]
+
+		eventDateTime?: string
+
+		feedback?: AlertFeedback
+
+		fileStates?: FileSecurityState[]
+
+		hostStates?: HostSecurityState[]
+
+		lastModifiedDateTime?: string
+
+		malwareStates?: MalwareState[]
+
+		networkConnections?: NetworkConnection[]
+
+		processes?: Process[]
+
+		recommendedActions?: string[]
+
+		registryKeyStates?: RegistryKeyState[]
+
+		severity?: AlertSeverity
+
+		sourceMaterials?: string[]
+
+		status?: AlertStatus
+
+		tags?: string[]
+
+		title?: string
+
+		triggers?: AlertTrigger[]
+
+		userStates?: UserSecurityState[]
+
+		vendorInformation?: SecurityVendorInformation
+
+		vulnerabilityStates?: VulnerabilityState[]
+
+}
+
+export interface Trending extends Entity {
+
+		weight?: number
+
+		resourceVisualization?: ResourceVisualization
+
+		resourceReference?: ResourceReference
+
+		lastModifiedDateTime?: string
+
+		resource?: Entity
+
+}
+
+export interface SharedInsight extends Entity {
+
+		lastShared?: SharingDetail
+
+		sharingHistory?: SharingDetail[]
+
+		resourceVisualization?: ResourceVisualization
+
+		resourceReference?: ResourceReference
+
+		lastSharedMethod?: Entity
+
+		resource?: Entity
+
+}
+
+export interface UsedInsight extends Entity {
+
+		lastUsed?: UsageDetails
+
+		resourceVisualization?: ResourceVisualization
+
+		resourceReference?: ResourceReference
+
+		resource?: Entity
+
 }
 export interface AlternativeSecurityId {
 
-				type?: number
-	    
-				identityProvider?: string
-	    
-				key?: number
-	    
+		type?: number
+
+		identityProvider?: string
+
+		key?: number
+
 }
 export interface DomainState {
 
 	    /** Current status of the operation.  Scheduled - Operation has been scheduled but has not started.  InProgress - Task has started and is in progress.  Failed - Operation has failed. */
-				status?: string
-	    
+		status?: string
+
 	    /** Type of asynchronous operation. The values can be ForceDelete or Verification */
-				operation?: string
-	    
+		operation?: string
+
 	    /** Timestamp for when the last activity occurred. The value is updated when an operation is scheduled, the asynchronous task starts, and when the operation completes. */
-				lastActionDateTime?: string
-	    
+		lastActionDateTime?: string
+
 }
 export interface ServicePlanInfo {
 
 	    /** The unique identifier of the service plan. */
-				servicePlanId?: string
-	    
+		servicePlanId?: string
+
 	    /** The name of the service plan. */
-				servicePlanName?: string
-	    
+		servicePlanName?: string
+
 	    /** The provisioning status of the service plan. Possible values:"Success" - Service is fully provisioned."Disabled" - Service has been disabled."PendingInput" - Service is not yet provisioned; awaiting service confirmation."PendingActivation" - Service is provisioned but requires explicit activation by administrator (for example, Intune_O365 service plan)"PendingProvisioning" - Microsoft has added a new service to the product SKU and it has not been activated in the tenant, yet. */
-				provisioningStatus?: string
-	    
+		provisioningStatus?: string
+
 	    /** The object the service plan can be assigned to. Possible values:"User" - service plan can be assigned to individual users."Company" - service plan can be assigned to the entire tenant. */
-				appliesTo?: string
-	    
+		appliesTo?: string
+
+}
+export interface OnPremisesProvisioningError {
+
+		value?: string
+
+		category?: string
+
+		propertyCausingError?: string
+
+		occurredDateTime?: string
+
 }
 export interface LicenseUnitsDetail {
 
 	    /** The number of units that are enabled. */
-				enabled?: number
-	    
+		enabled?: number
+
 	    /** The number of units that are suspended. */
-				suspended?: number
-	    
+		suspended?: number
+
 	    /** The number of units that are in warning status. */
-				warning?: number
-	    
+		warning?: number
+
 }
 export interface AssignedPlan {
 
 	    /** The date and time at which the plan was assigned; for example: 2013-01-02T19:32:30Z. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-				assignedDateTime?: string
-	    
-	    /** For example, “Enabled”. */
-				capabilityStatus?: string
-	    
-	    /** The name of the service; for example, “Exchange”. */
-				service?: string
-	    
+		assignedDateTime?: string
+
+	    /** For example, "Enabled". */
+		capabilityStatus?: string
+
+	    /** The name of the service; for example, "Exchange". */
+		service?: string
+
 	    /** A GUID that identifies the service plan. */
-				servicePlanId?: string
-	    
+		servicePlanId?: string
+
 }
 export interface PrivacyProfile {
 
 	    /** A valid smtp email address for the privacy statement contact. Not required. */
-				contactEmail?: string
-	    
+		contactEmail?: string
+
 	    /** A valid URL format that begins with http:// or https://. Maximum length is 255 characters. The URL that directs to the company's privacy statement. Not required. */
-				statementUrl?: string
-	    
+		statementUrl?: string
+
 }
 export interface ProvisionedPlan {
 
-				capabilityStatus?: string
-	    
-				provisioningStatus?: string
-	    
-				service?: string
-	    
+		capabilityStatus?: string
+
+		provisioningStatus?: string
+
+		service?: string
+
 }
 export interface VerifiedDomain {
 
-				capabilities?: string
-	    
-				isDefault?: boolean
-	    
-				isInitial?: boolean
-	    
-				name?: string
-	    
-				type?: string
-	    
+		capabilities?: string
+
+		isDefault?: boolean
+
+		isInitial?: boolean
+
+		name?: string
+
+		type?: string
+
 }
 export interface AssignedLicense {
 
 	    /** A collection of the unique identifiers for plans that have been disabled. */
-				disabledPlans: string[]
-	    
+		disabledPlans?: string[]
+
 	    /** The unique identifier for the SKU. */
-				skuId?: string
-	    
+		skuId?: string
+
+}
+export interface OnPremisesExtensionAttributes {
+
+		extensionAttribute1?: string
+
+		extensionAttribute2?: string
+
+		extensionAttribute3?: string
+
+		extensionAttribute4?: string
+
+		extensionAttribute5?: string
+
+		extensionAttribute6?: string
+
+		extensionAttribute7?: string
+
+		extensionAttribute8?: string
+
+		extensionAttribute9?: string
+
+		extensionAttribute10?: string
+
+		extensionAttribute11?: string
+
+		extensionAttribute12?: string
+
+		extensionAttribute13?: string
+
+		extensionAttribute14?: string
+
+		extensionAttribute15?: string
+
 }
 export interface PasswordProfile {
 
-				password?: string
-	    
-				forceChangePasswordNextSignIn?: boolean
-	    
+		password?: string
+
+		forceChangePasswordNextSignIn?: boolean
+
 }
 export interface MailboxSettings {
 
 	    /** Configuration settings to automatically notify the sender of an incoming email with a message from the signed-in user. */
-				automaticRepliesSetting?: AutomaticRepliesSetting
-	    
+		automaticRepliesSetting?: AutomaticRepliesSetting
+
 	    /** Folder ID of an archive folder for the user. */
-				archiveFolder?: string
-	    
+		archiveFolder?: string
+
 	    /** The default time zone for the user's mailbox. */
-				timeZone?: string
-	    
+		timeZone?: string
+
 	    /** The locale information for the user, including the preferred language and country/region. */
-				language?: LocaleInfo
-	    
+		language?: LocaleInfo
+
 	    /** The days of the week and hours in a specific time zone that the user works. */
-				workingHours?: WorkingHours
-	    
+		workingHours?: WorkingHours
+
 }
 export interface AutomaticRepliesSetting {
 
 	    /** Configurations status for automatic replies. Possible values are: disabled, alwaysEnabled, scheduled. */
-				status?: AutomaticRepliesStatus
-	    
+		status?: AutomaticRepliesStatus
+
 	    /** The set of audience external to the signed-in user's organization who will receive the ExternalReplyMessage, if Status is AlwaysEnabled or Scheduled. Possible values are: none, contactsOnly, all. */
-				externalAudience?: ExternalAudienceScope
-	    
+		externalAudience?: ExternalAudienceScope
+
 	    /** The date and time that automatic replies are set to begin, if Status is set to Scheduled. */
-				scheduledStartDateTime?: DateTimeTimeZone
-	    
+		scheduledStartDateTime?: DateTimeTimeZone
+
 	    /** The date and time that automatic replies are set to end, if Status is set to Scheduled. */
-				scheduledEndDateTime?: DateTimeTimeZone
-	    
+		scheduledEndDateTime?: DateTimeTimeZone
+
 	    /** The automatic reply to send to the audience internal to the signed-in user's organization, if Status is AlwaysEnabled or Scheduled. */
-				internalReplyMessage?: string
-	    
+		internalReplyMessage?: string
+
 	    /** The automatic reply to send to the specified external audience, if Status is AlwaysEnabled or Scheduled. */
-				externalReplyMessage?: string
-	    
+		externalReplyMessage?: string
+
 }
 export interface DateTimeTimeZone {
 
-				dateTime: string
-	    
-				timeZone?: string
-	    
+		dateTime?: string
+
+		timeZone?: string
+
 }
 export interface LocaleInfo {
 
 	    /** A locale representation for the user, which includes the user's preferred language and country/region. For example, "en-us". The language component follows 2-letter codes as defined in ISO 639-1, and the country component follows 2-letter codes as defined in ISO 3166-1 alpha-2. */
-				locale?: string
-	    
+		locale?: string
+
 	    /** A name representing the user's locale in natural language, for example, "English (United States)". */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface WorkingHours {
 
 	    /** The days of the week on which the user works. */
-				daysOfWeek?: DayOfWeek[]
-	    
+		daysOfWeek?: DayOfWeek[]
+
 	    /** The time of the day that the user starts working. */
-				startTime?: string
-	    
+		startTime?: string
+
 	    /** The time of the day that the user stops working. */
-				endTime?: string
-	    
+		endTime?: string
+
 	    /** The time zone to which the working hours apply. */
-				timeZone?: TimeZoneBase
-	    
+		timeZone?: TimeZoneBase
+
 }
 export interface TimeZoneBase {
 
 	    /** The name of a time zone. It can be a standard time zone name such as "Hawaii-Aleutian Standard Time", or "Customized Time Zone" for a custom time zone. */
-				name?: string
-	    
+		name?: string
+
 }
 export interface SettingValue {
 
 	    /** Name of the setting (as defined by the groupSettingTemplate). */
-				name?: string
-	    
+		name?: string
+
 	    /** Value of the setting. */
-				value?: string
-	    
+		value?: string
+
 }
 export interface SettingTemplateValue {
 
 	    /** Name of the setting. */
-				name?: string
-	    
+		name?: string
+
 	    /** Type of the setting. */
-				type?: string
-	    
+		type?: string
+
 	    /** Default value for the setting. */
-				defaultValue?: string
-	    
+		defaultValue?: string
+
 	    /** Description of the setting. */
-				description?: string
-	    
+		description?: string
+
 }
 export interface ComplexExtensionValue {
 
@@ -8206,594 +8543,641 @@ export interface ComplexExtensionValue {
 export interface ExtensionSchemaProperty {
 
 	    /** The name of the strongly-typed property defined as part of a schema extension. */
-				name?: string
-	    
+		name?: string
+
 	    /** The type of the property that is defined as part of a schema extension.  Allowed values are Binary, Boolean, DateTime, Integer or String.  See the table below for more details. */
-				type?: string
-	    
+		type?: string
+
 }
 export interface CustomTimeZone extends TimeZoneBase {
 
 	    /** The time offset of the time zone from Coordinated Universal Time (UTC). This value is in minutes. Time zones that are ahead of UTC have a positive offset; time zones that are behind UTC have a negative offset. */
-				bias?: number
-	    
+		bias?: number
+
 	    /** Specifies when the time zone switches from daylight saving time to standard time. */
-				standardOffset?: StandardTimeZoneOffset
-	    
+		standardOffset?: StandardTimeZoneOffset
+
 	    /** Specifies when the time zone switches from standard time to daylight saving time. */
-				daylightOffset?: DaylightTimeZoneOffset
-	    
+		daylightOffset?: DaylightTimeZoneOffset
+
 }
 export interface StandardTimeZoneOffset {
 
 	    /** Represents the time of day when the transition from daylight saving time to standard time occurs. */
-				time?: string
-	    
+		time?: string
+
 	    /** Represents the nth occurrence of the day of week that the transition from daylight saving time to standard time occurs. */
-				dayOccurrence?: number
-	    
+		dayOccurrence?: number
+
 	    /** Represents the day of the week when the transition from daylight saving time to standard time. */
-				dayOfWeek?: DayOfWeek
-	    
+		dayOfWeek?: DayOfWeek
+
 	    /** Represents the month of the year when the transition from daylight saving time to standard time occurs. */
-				month?: number
-	    
+		month?: number
+
 	    /** Represents how frequently in terms of years the change from daylight saving time to standard time occurs. For example, a value of 0 means every year. */
-				year?: number
-	    
+		year?: number
+
 }
 export interface DaylightTimeZoneOffset extends StandardTimeZoneOffset {
 
 	    /** The time offset from Coordinated Universal Time (UTC) for daylight saving time. This value is in minutes. */
-				daylightBias?: number
-	    
+		daylightBias?: number
+
 }
 export interface Recipient {
 
 	    /** The recipient's email address. */
-				emailAddress?: EmailAddress
-	    
+		emailAddress?: EmailAddress
+
 }
 export interface EmailAddress {
 
 	    /** The display name of the person or entity. */
-				name?: string
-	    
+		name?: string
+
 	    /** The email address of the person or entity. */
-				address?: string
-	    
+		address?: string
+
 }
 export interface AttendeeBase extends Recipient {
 
 	    /** The type of attendee. Possible values are: required, optional, resource. Currently if the attendee is a person, findMeetingTimes always considers the person is of the Required type. */
-				type?: AttendeeType
-	    
+		type?: AttendeeType
+
 }
 export interface MeetingTimeSuggestionsResult {
 
 	    /** An array of meeting suggestions. */
-				meetingTimeSuggestions?: MeetingTimeSuggestion[]
-	    
+		meetingTimeSuggestions?: MeetingTimeSuggestion[]
+
 	    /** A reason for not returning any meeting suggestions. Possible values are: attendeesUnavailable, attendeesUnavailableOrUnknown, locationsUnavailable, organizerUnavailable, or unknown. This property is an empty string if the meetingTimeSuggestions property does include any meeting suggestions. */
-				emptySuggestionsReason?: string
-	    
+		emptySuggestionsReason?: string
+
 }
 export interface MeetingTimeSuggestion {
 
 	    /** A time period suggested for the meeting. */
-				meetingTimeSlot?: TimeSlot
-	    
+		meetingTimeSlot?: TimeSlot
+
 	    /** A percentage that represents the likelhood of all the attendees attending. */
-				confidence?: number
-	    
+		confidence?: number
+
 	    /** Availability of the meeting organizer for this meeting suggestion. Possible values are: free, tentative, busy, oof, workingElsewhere, unknown. */
-				organizerAvailability?: FreeBusyStatus
-	    
+		organizerAvailability?: FreeBusyStatus
+
 	    /** An array that shows the availability status of each attendee for this meeting suggestion. */
-				attendeeAvailability?: AttendeeAvailability[]
-	    
+		attendeeAvailability?: AttendeeAvailability[]
+
 	    /** An array that specifies the name and geographic location of each meeting location for this meeting suggestion. */
-				locations?: Location[]
-	    
+		locations?: Location[]
+
 	    /** Reason for suggesting the meeting time. */
-				suggestionReason?: string
-	    
+		suggestionReason?: string
+
 }
 export interface TimeSlot {
 
 	    /** The time the period ends. */
-				start?: DateTimeTimeZone
-	    
+		start?: DateTimeTimeZone
+
 	    /** The time a period begins. */
-				end?: DateTimeTimeZone
-	    
+		end?: DateTimeTimeZone
+
 }
 export interface AttendeeAvailability {
 
 	    /** The type of attendee - whether it's a person or a resource, and whether required or optional if it's a person. */
-				attendee?: AttendeeBase
-	    
+		attendee?: AttendeeBase
+
 	    /** The availability status of the attendee. Possible values are: free, tentative, busy, oof, workingElsewhere, unknown. */
-				availability?: FreeBusyStatus
-	    
+		availability?: FreeBusyStatus
+
 }
 export interface Location {
 
 	    /** The name associated with the location. */
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** Optional email address of the location. */
-				locationEmailAddress?: string
-	    
+		locationEmailAddress?: string
+
 	    /** The street address of the location. */
-				address?: PhysicalAddress
-	    
+		address?: PhysicalAddress
+
 	    /** The geographic coordinates and elevation of the location. */
-				coordinates?: OutlookGeoCoordinates
-	    
+		coordinates?: OutlookGeoCoordinates
+
 	    /** Optional URI representing the location. */
-				locationUri?: string
-	    
+		locationUri?: string
+
 	    /** The type of location. Possible values are: default, conferenceRoom, homeAddress, businessAddress,geoCoordinates, streetAddress, hotel, restaurant, localBusiness, postalAddress. Read-only. */
-				locationType?: LocationType
-	    
+		locationType?: LocationType
+
 	    /** For internal use only. */
-				uniqueId?: string
-	    
+		uniqueId?: string
+
 	    /** For internal use only. */
-				uniqueIdType?: LocationUniqueIdType
-	    
+		uniqueIdType?: LocationUniqueIdType
+
 }
 export interface PhysicalAddress {
 
 	    /** The street. */
-				street?: string
-	    
+		street?: string
+
 	    /** The city. */
-				city?: string
-	    
+		city?: string
+
 	    /** The state. */
-				state?: string
-	    
+		state?: string
+
 	    /** The country or region. It's a free-format string value, for example, "United States". */
-				countryOrRegion?: string
-	    
+		countryOrRegion?: string
+
 	    /** The postal code. */
-				postalCode?: string
-	    
+		postalCode?: string
+
 }
 export interface OutlookGeoCoordinates {
 
 	    /** The altitude of the location. */
-				altitude?: number
-	    
+		altitude?: number
+
 	    /** The latitude of the location. */
-				latitude?: number
-	    
+		latitude?: number
+
 	    /** The longitude of the location. */
-				longitude?: number
-	    
+		longitude?: number
+
 	    /** The accuracy of the latitude and longitude. As an example, the accuracy can be measured in meters, such as the latitude and longitude are accurate to within 50 meters. */
-				accuracy?: number
-	    
+		accuracy?: number
+
 	    /** The accuracy of the altitude. */
-				altitudeAccuracy?: number
-	    
+		altitudeAccuracy?: number
+
 }
 export interface LocationConstraint {
 
-				isRequired?: boolean
-	    
-				suggestLocation?: boolean
-	    
-				locations?: LocationConstraintItem[]
-	    
+		isRequired?: boolean
+
+		suggestLocation?: boolean
+
+		locations?: LocationConstraintItem[]
+
 }
 export interface LocationConstraintItem extends Location {
 
 	    /** If set to true and the specified resource is busy, findMeetingTimes looks for another resource that is free. If set to false and the specified resource is busy, findMeetingTimes returns the resource best ranked in the user's cache without checking if it's free. Default is true. */
-				resolveAvailability?: boolean
-	    
+		resolveAvailability?: boolean
+
 }
 export interface TimeConstraint {
 
-				activityDomain?: ActivityDomain
-	    
-				timeslots?: TimeSlot[]
-	    
+		activityDomain?: ActivityDomain
+
+		timeslots?: TimeSlot[]
+
 }
 export interface Reminder {
 
 	    /** The unique ID of the event. Read only. */
-				eventId?: string
-	    
+		eventId?: string
+
 	    /** The date, time, and time zone that the event starts. */
-				eventStartTime?: DateTimeTimeZone
-	    
+		eventStartTime?: DateTimeTimeZone
+
 	    /** The date, time and time zone that the event ends. */
-				eventEndTime?: DateTimeTimeZone
-	    
+		eventEndTime?: DateTimeTimeZone
+
 	    /** Identifies the version of the reminder. Every time the reminder is changed, changeKey changes as well. This allows Exchange to apply changes to the correct version of the object. */
-				changeKey?: string
-	    
+		changeKey?: string
+
 	    /** The text of the event's subject line. */
-				eventSubject?: string
-	    
+		eventSubject?: string
+
 	    /** The location of the event. */
-				eventLocation?: Location
-	    
+		eventLocation?: Location
+
 	    /** The URL to open the event in Outlook on the web.The event will open in the browser if you are logged in to your mailbox via Outlook on the web. You will be prompted to login if you are not already logged in with the browser.This URL can be accessed from within an iFrame. */
-				eventWebLink?: string
-	    
+		eventWebLink?: string
+
 	    /** The date, time, and time zone that the reminder is set to occur. */
-				reminderFireTime?: DateTimeTimeZone
-	    
+		reminderFireTime?: DateTimeTimeZone
+
+}
+export interface MailTips {
+
+		emailAddress?: EmailAddress
+
+		automaticReplies?: AutomaticRepliesMailTips
+
+		mailboxFull?: boolean
+
+		customMailTip?: string
+
+		externalMemberCount?: number
+
+		totalMemberCount?: number
+
+		deliveryRestricted?: boolean
+
+		isModerated?: boolean
+
+		recipientScope?: RecipientScopeType
+
+		recipientSuggestions?: Recipient[]
+
+		maxMessageSize?: number
+
+		error?: MailTipsError
+
+}
+export interface AutomaticRepliesMailTips {
+
+		message?: string
+
+		messageLanguage?: LocaleInfo
+
+		scheduledStartTime?: DateTimeTimeZone
+
+		scheduledEndTime?: DateTimeTimeZone
+
+}
+export interface MailTipsError {
+
+		message?: string
+
+		code?: string
+
 }
 export interface TimeZoneInformation {
 
 	    /** An identifier for the time zone. */
-				alias?: string
-	    
+		alias?: string
+
 	    /** A display string that represents the time zone. */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface InternetMessageHeader {
 
 	    /** Represents the key in a key-value pair. */
-				name?: string
-	    
+		name?: string
+
 	    /** The value in a key-value pair. */
-				value?: string
-	    
+		value?: string
+
 }
 export interface ItemBody {
 
 	    /** The type of the content. Possible values are Text and HTML. */
-				contentType?: BodyType
-	    
+		contentType?: BodyType
+
 	    /** The content of the item. */
-				content?: string
-	    
+		content?: string
+
 }
 export interface FollowupFlag {
 
 	    /** The date and time that the follow-up was finished. */
-				completedDateTime?: DateTimeTimeZone
-	    
+		completedDateTime?: DateTimeTimeZone
+
 	    /** The date and time that the follow-up is to be finished. */
-				dueDateTime?: DateTimeTimeZone
-	    
+		dueDateTime?: DateTimeTimeZone
+
 	    /** The date and time that the follow-up is to begin. */
-				startDateTime?: DateTimeTimeZone
-	    
+		startDateTime?: DateTimeTimeZone
+
 	    /** The status for follow-up for an item. Possible values are notFlagged, complete, and flagged. */
-				flagStatus?: FollowupFlagStatus
-	    
+		flagStatus?: FollowupFlagStatus
+
 }
 export interface ResponseStatus {
 
 	    /** The response type. Possible values are: None, Organizer, TentativelyAccepted, Accepted, Declined, NotResponded. */
-				response?: ResponseType
-	    
+		response?: ResponseType
+
 	    /** The date and time that the response was returned. It uses ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-				time?: string
-	    
+		time?: string
+
 }
 export interface PatternedRecurrence {
 
 	    /** The frequency of an event. */
-				pattern?: RecurrencePattern
-	    
+		pattern?: RecurrencePattern
+
 	    /** The duration of an event. */
-				range?: RecurrenceRange
-	    
+		range?: RecurrenceRange
+
 }
 export interface RecurrencePattern {
 
 	    /** The recurrence pattern type: daily, weekly, absoluteMonthly, relativeMonthly, absoluteYearly, relativeYearly. Required. */
-				type?: RecurrencePatternType
-	    
+		type?: RecurrencePatternType
+
 	    /** The number of units between occurrences, where units can be in days, weeks, months, or years, depending on the type. Required. */
-				interval: number
-	    
+		interval?: number
+
 	    /** The month in which the event occurs.  This is a number from 1 to 12. */
-				month: number
-	    
+		month?: number
+
 	    /** The day of the month on which the event occurs. Required if type is absoluteMonthly or absoluteYearly. */
-				dayOfMonth: number
-	    
+		dayOfMonth?: number
+
 	    /** A collection of the days of the week on which the event occurs. Possible values are: sunday, monday, tuesday, wednesday, thursday, friday, saturday. If type is relativeMonthly or relativeYearly, and daysOfWeek specifies more than one day, the event falls on the first day that satisfies the pattern.  Required if type is weekly, relativeMonthly, or relativeYearly. */
-				daysOfWeek?: DayOfWeek[]
-	    
+		daysOfWeek?: DayOfWeek[]
+
 	    /** The first day of the week. Possible values are: sunday, monday, tuesday, wednesday, thursday, friday, saturday. Default is sunday. Required if type is weekly. */
-				firstDayOfWeek?: DayOfWeek
-	    
+		firstDayOfWeek?: DayOfWeek
+
 	    /** Specifies on which instance of the allowed days specified in daysOfsWeek the event occurs, counted from the first instance in the month. Possible values are: first, second, third, fourth, last. Default is first. Optional and used if type is relativeMonthly or relativeYearly. */
-				index?: WeekIndex
-	    
+		index?: WeekIndex
+
 }
 export interface RecurrenceRange {
 
 	    /** The recurrence range. Possible values are: endDate, noEnd, numbered. Required. */
-				type?: RecurrenceRangeType
-	    
+		type?: RecurrenceRangeType
+
 	    /** The date to start applying the recurrence pattern. The first occurrence of the meeting may be this date or later, depending on the recurrence pattern of the event. Must be the same value as the start property of the recurring event. Required. */
-				startDate?: string
-	    
+		startDate?: string
+
 	    /** The date to stop applying the recurrence pattern. Depending on the recurrence pattern of the event, the last occurrence of the meeting may not be this date. Required if type is endDate. */
-				endDate?: string
-	    
+		endDate?: string
+
 	    /** Time zone for the startDate and endDate properties. Optional. If not specified, the time zone of the event is used. */
-				recurrenceTimeZone?: string
-	    
+		recurrenceTimeZone?: string
+
 	    /** The number of times to repeat the event. Required and must be positive if type is numbered. */
-				numberOfOccurrences: number
-	    
+		numberOfOccurrences?: number
+
 }
 export interface Attendee extends AttendeeBase {
 
 	    /** The attendee's response (none, accepted, declined, etc.) for the event and date-time that the response was sent. */
-				status?: ResponseStatus
-	    
+		status?: ResponseStatus
+
 }
 export interface MessageRulePredicates {
 
 	    /** Represents the categories that an incoming message should be labeled with in order for the condition or exception to apply. */
-				categories?: string[]
-	    
+		categories?: string[]
+
 	    /** Represents the strings that appear in the subject of an incoming message in order for the condition or exception to apply. */
-				subjectContains?: string[]
-	    
+		subjectContains?: string[]
+
 	    /** Represents the strings that should appear in the body of an incoming message in order for the condition or exception to apply. */
-				bodyContains?: string[]
-	    
+		bodyContains?: string[]
+
 	    /** Represents the strings that should appear in the body or subject of an incoming message in order for the condition or exception to apply. */
-				bodyOrSubjectContains?: string[]
-	    
+		bodyOrSubjectContains?: string[]
+
 	    /** Represents the strings that appear in the from property of an incoming message in order for the condition or exception to apply. */
-				senderContains?: string[]
-	    
+		senderContains?: string[]
+
 	    /** Represents the strings that appear in either the toRecipients or ccRecipients properties of an incoming message in order for the condition or exception to apply. */
-				recipientContains?: string[]
-	    
+		recipientContains?: string[]
+
 	    /** Represents the strings that appear in the headers of an incoming message in order for the condition or exception to apply. */
-				headerContains?: string[]
-	    
+		headerContains?: string[]
+
 	    /** Represents the flag-for-action value that appears on an incoming message in order for the condition or exception to apply. Possible values are: any, call, doNotForward, followUp, fyi, forward, noResponseNecessary, read, reply, replyToAll, review. */
-				messageActionFlag?: MessageActionFlag
-	    
+		messageActionFlag?: MessageActionFlag
+
 	    /** The importance that is stamped on an incoming message in order for the condition or exception to apply: low, normal, high. */
-				importance?: Importance
-	    
+		importance?: Importance
+
 	    /** Represents the sensitivity level that must be stamped on an incoming message in order for the condition or exception to apply. Possible values are: normal, personal, private, confidential. */
-				sensitivity?: Sensitivity
-	    
+		sensitivity?: Sensitivity
+
 	    /** Represents the specific sender email addresses of an incoming message in order for the condition or exception to apply. */
-				fromAddresses?: Recipient[]
-	    
+		fromAddresses?: Recipient[]
+
 	    /** Represents the email addresses that an incoming message must have been sent to in order for the condition or exception to apply. */
-				sentToAddresses?: Recipient[]
-	    
+		sentToAddresses?: Recipient[]
+
 	    /** Indicates whether the owner of the mailbox must be in the toRecipients property of an incoming message in order for the condition or exception to apply. */
-				sentToMe?: boolean
-	    
+		sentToMe?: boolean
+
 	    /** Indicates whether the owner of the mailbox must be the only recipient in an incoming message in order for the condition or exception to apply. */
-				sentOnlyToMe?: boolean
-	    
+		sentOnlyToMe?: boolean
+
 	    /** Indicates whether the owner of the mailbox must be in the ccRecipients property of an incoming message in order for the condition or exception to apply. */
-				sentCcMe?: boolean
-	    
+		sentCcMe?: boolean
+
 	    /** Indicates whether the owner of the mailbox must be in either a toRecipients or ccRecipients property of an incoming message in order for the condition or exception to apply. */
-				sentToOrCcMe?: boolean
-	    
+		sentToOrCcMe?: boolean
+
 	    /** Indicates whether the owner of the mailbox must not be a recipient of an incoming message in order for the condition or exception to apply. */
-				notSentToMe?: boolean
-	    
+		notSentToMe?: boolean
+
 	    /** Indicates whether an incoming message must have attachments in order for the condition or exception to apply. */
-				hasAttachments?: boolean
-	    
+		hasAttachments?: boolean
+
 	    /** Indicates whether an incoming message must be an approval request in order for the condition or exception to apply. */
-				isApprovalRequest?: boolean
-	    
+		isApprovalRequest?: boolean
+
 	    /** Indicates whether an incoming message must be automatically forwarded in order for the condition or exception to apply. */
-				isAutomaticForward?: boolean
-	    
+		isAutomaticForward?: boolean
+
 	    /** Indicates whether an incoming message must be an auto reply in order for the condition or exception to apply. */
-				isAutomaticReply?: boolean
-	    
+		isAutomaticReply?: boolean
+
 	    /** Indicates whether an incoming message must be encrypted in order for the condition or exception to apply. */
-				isEncrypted?: boolean
-	    
+		isEncrypted?: boolean
+
 	    /** Indicates whether an incoming message must be a meeting request in order for the condition or exception to apply. */
-				isMeetingRequest?: boolean
-	    
+		isMeetingRequest?: boolean
+
 	    /** Indicates whether an incoming message must be a meeting response in order for the condition or exception to apply. */
-				isMeetingResponse?: boolean
-	    
+		isMeetingResponse?: boolean
+
 	    /** Indicates whether an incoming message must be a non-delivery report in order for the condition or exception to apply. */
-				isNonDeliveryReport?: boolean
-	    
+		isNonDeliveryReport?: boolean
+
 	    /** Indicates whether an incoming message must be permission controlled (RMS-protected) in order for the condition or exception to apply. */
-				isPermissionControlled?: boolean
-	    
+		isPermissionControlled?: boolean
+
 	    /** Indicates whether an incoming message must be a read receipt in order for the condition or exception to apply. */
-				isReadReceipt?: boolean
-	    
+		isReadReceipt?: boolean
+
 	    /** Indicates whether an incoming message must be S/MIME-signed in order for the condition or exception to apply. */
-				isSigned?: boolean
-	    
+		isSigned?: boolean
+
 	    /** Indicates whether an incoming message must be a voice mail in order for the condition or exception to apply. */
-				isVoicemail?: boolean
-	    
+		isVoicemail?: boolean
+
 	    /** Represents the minimum and maximum sizes (in kilobytes) that an incoming message must fall in between in order for the condition or exception to apply. */
-				withinSizeRange?: SizeRange
-	    
+		withinSizeRange?: SizeRange
+
 }
 export interface SizeRange {
 
 	    /** The minimum size (in kilobytes) that an incoming message must have in order for a condition or exception to apply. */
-				minimumSize?: number
-	    
+		minimumSize?: number
+
 	    /** The maximum size (in kilobytes) that an incoming message must have in order for a condition or exception to apply. */
-				maximumSize?: number
-	    
+		maximumSize?: number
+
 }
 export interface MessageRuleActions {
 
 	    /** The ID of the folder that a message will be moved to. */
-				moveToFolder?: string
-	    
+		moveToFolder?: string
+
 	    /** The ID of a folder that a message is to be copied to. */
-				copyToFolder?: string
-	    
+		copyToFolder?: string
+
 	    /** Indicates whether a message should be moved to the Deleted Items folder. */
-				delete?: boolean
-	    
+		delete?: boolean
+
 	    /** Indicates whether a message should be permanently deleted and not saved to the Deleted Items folder. */
-				permanentDelete?: boolean
-	    
+		permanentDelete?: boolean
+
 	    /** Indicates whether a message should be marked as read. */
-				markAsRead?: boolean
-	    
+		markAsRead?: boolean
+
 	    /** Sets the importance of the message, which can be: low, normal, high. */
-				markImportance?: Importance
-	    
+		markImportance?: Importance
+
 	    /** The email addresses of the recipients to which a message should be forwarded. */
-				forwardTo?: Recipient[]
-	    
+		forwardTo?: Recipient[]
+
 	    /** The email addresses of the recipients to which a message should be forwarded as an attachment. */
-				forwardAsAttachmentTo?: Recipient[]
-	    
+		forwardAsAttachmentTo?: Recipient[]
+
 	    /** The email address to which a message should be redirected. */
-				redirectTo?: Recipient[]
-	    
+		redirectTo?: Recipient[]
+
 	    /** A list of categories to be assigned to a message. */
-				assignCategories?: string[]
-	    
+		assignCategories?: string[]
+
 	    /** Indicates whether subsequent rules should be evaluated. */
-				stopProcessingRules?: boolean
-	    
+		stopProcessingRules?: boolean
+
 }
 export interface ScoredEmailAddress {
 
 	    /** The email address. */
-				address?: string
-	    
-	    /** The relevance score of the email address. A relevance score is used as a sort key, in relation to the other returned results. A higher relevance score value corresponds to a more relevant result. Relevance is determined by the user’s communication and collaboration patterns and business relationships. */
-				relevanceScore?: number
-	    
-				selectionLikelihood?: SelectionLikelihoodInfo
-	    
+		address?: string
+
+	    /** The relevance score of the email address. A relevance score is used as a sort key, in relation to the other returned results. A higher relevance score value corresponds to a more relevant result. Relevance is determined by the user's communication and collaboration patterns and business relationships. */
+		relevanceScore?: number
+
+		selectionLikelihood?: SelectionLikelihoodInfo
+
+		ItemId?: string
+
 }
 export interface Phone {
 
 	    /** The type of phone number. Possible values are: home, business, mobile, other, assistant, homeFax, businessFax, otherFax, pager, radio. */
-				type?: PhoneType
-	    
+		type?: PhoneType
+
 	    /** The phone number. */
-				number?: string
-	    
-				region?: string
-	    
-				language?: string
-	    
+		number?: string
+
+		region?: string
+
+		language?: string
+
 }
 export interface Website {
 
 	    /** Possible values are: other, home, work, blog, profile. */
-				type?: WebsiteType
-	    
+		type?: WebsiteType
+
 	    /** The URL of the website. */
-				address?: string
-	    
+		address?: string
+
 	    /** The display name of the web site. */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface PersonType {
 
 	    /** The type of data source, such as Person. */
-				class?: string
-	    
+		class?: string
+
 	    /** The secondary type of data source, such as OrganizationUser. */
-				subclass?: string
-	    
+		subclass?: string
+
 }
 export interface IdentitySet {
 
 	    /** Optional. The application associated with this action. */
-				application?: Identity
-	    
+		application?: Identity
+
 	    /** Optional. The device associated with this action. */
-				device?: Identity
-	    
+		device?: Identity
+
 	    /** Optional. The user associated with this action. */
-				user?: Identity
-	    
+		user?: Identity
+
 }
 export interface Identity {
 
 	    /** The identity's display name. Note that this may not always be available or up to date. For example, if a user changes their display name, the API may show the new value in a future response, but the items associated with the user won't show up as having changed when using delta. */
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** Unique identifier for the identity. */
-				id?: string
-	    
+		id?: string
+
 }
 export interface ItemReference {
 
 	    /** Unique identifier of the drive instance that contains the item. Read-only. */
-				driveId?: string
-	    
+		driveId?: string
+
 	    /** Identifies the type of drive. See [drive][] resource for values. */
-				driveType?: string
-	    
+		driveType?: string
+
 	    /** Unique identifier of the item in the drive. Read-only. */
-				id?: string
-	    
+		id?: string
+
 	    /** The name of the item being referenced. Read-only. */
-				name?: string
-	    
+		name?: string
+
 	    /** Path that can be used to navigate to the item. Read-only. */
-				path?: string
-	    
+		path?: string
+
 	    /** A unique identifier for a shared resource that can be accessed via the [Shares][] API. */
-				shareId?: string
-	    
+		shareId?: string
+
 	    /** Returns identifiers useful for SharePoint REST compatibility. Read-only. */
-				sharepointIds?: SharepointIds
-	    
+		sharepointIds?: SharepointIds
+
 }
 export interface SharepointIds {
 
 	    /** The unique identifier (guid) for the item's list in SharePoint. */
-				listId?: string
-	    
+		listId?: string
+
 	    /** An integer identifier for the item within the containing list. */
-				listItemId?: string
-	    
+		listItemId?: string
+
 	    /** The unique identifier (guid) for the item within OneDrive for Business or a SharePoint site. */
-				listItemUniqueId?: string
-	    
+		listItemUniqueId?: string
+
 	    /** The unique identifier (guid) for the item's site collection (SPSite). */
-				siteId?: string
-	    
+		siteId?: string
+
 	    /** The SharePoint URL for the site that contains the item. */
-				siteUrl?: string
-	    
+		siteUrl?: string
+
 	    /** The unique identifier (guid) for the item's site (SPWeb). */
-				webId?: string
-	    
+		webId?: string
+
 }
 export interface PublicationFacet {
 
 	    /** The state of publication for this document. Either published or checkout. Read-only. */
-				level?: string
-	    
+		level?: string
+
 	    /** The unique identifier for the version that is visible to the current caller. Read-only. */
-				versionId?: string
-	    
+		versionId?: string
+
 }
 export interface BooleanColumn {
 
@@ -8801,140 +9185,140 @@ export interface BooleanColumn {
 export interface CalculatedColumn {
 
 	    /** For dateTime output types, the format of the value. Must be one of dateOnly or dateTime. */
-				format?: string
-	    
+		format?: string
+
 	    /** The formula used to compute the value for this column. */
-				formula?: string
-	    
+		formula?: string
+
 	    /** The output type used to format values in this column. Must be one of boolean, currency, dateTime, number, or text. */
-				outputType?: string
-	    
+		outputType?: string
+
 }
 export interface ChoiceColumn {
 
 	    /** If true, allows custom values that aren't in the configured choices. */
-				allowTextEntry?: boolean
-	    
+		allowTextEntry?: boolean
+
 	    /** The list of values available for this column. */
-				choices?: string[]
-	    
+		choices?: string[]
+
 	    /** How the choices are to be presented in the UX. Must be one of checkBoxes, dropDownMenu, or radioButtons */
-				displayAs?: string
-	    
+		displayAs?: string
+
 }
 export interface CurrencyColumn {
 
 	    /** Specifies the locale from which to infer the currency symbol. */
-				locale?: string
-	    
+		locale?: string
+
 }
 export interface DateTimeColumn {
 
 	    /** How the value should be presented in the UX. Must be one of default, friendly, or standard. See below for more details. If unspecified, treated as default. */
-				displayAs?: string
-	    
+		displayAs?: string
+
 	    /** Indicates whether the value should be presented as a date only or a date and time. Must be one of dateOnly or dateTime */
-				format?: string
-	    
+		format?: string
+
 }
 export interface DefaultColumnValue {
 
 	    /** The formula used to compute the default value for this column. */
-				formula?: string
-	    
+		formula?: string
+
 	    /** The direct value to use as the default value for this column. */
-				value?: string
-	    
+		value?: string
+
 }
 export interface LookupColumn {
 
 	    /** Indicates whether multiple values can be selected from the source. */
-				allowMultipleValues?: boolean
-	    
+		allowMultipleValues?: boolean
+
 	    /** Indicates whether values in the column should be able to exceed the standard limit of 255 characters. */
-				allowUnlimitedLength?: boolean
-	    
+		allowUnlimitedLength?: boolean
+
 	    /** The name of the lookup source column. */
-				columnName?: string
-	    
+		columnName?: string
+
 	    /** The unique identifier of the lookup source list. */
-				listId?: string
-	    
+		listId?: string
+
 	    /** If specified, this column is a secondary lookup, pulling an additional field from the list item looked up by the primary lookup. Use the list item looked up by the primary as the source for the column named here. */
-				primaryLookupColumnId?: string
-	    
+		primaryLookupColumnId?: string
+
 }
 export interface NumberColumn {
 
 	    /** How many decimal places to display. See below for information about the possible values. */
-				decimalPlaces?: string
-	    
+		decimalPlaces?: string
+
 	    /** How the value should be presented in the UX. Must be one of number or percentage. If unspecified, treated as number. */
-				displayAs?: string
-	    
+		displayAs?: string
+
 	    /** The maximum permitted value. */
-				maximum?: number
-	    
+		maximum?: number
+
 	    /** The minimum permitted value. */
-				minimum?: number
-	    
+		minimum?: number
+
 }
 export interface PersonOrGroupColumn {
 
 	    /** Indicates whether multiple values can be selected from the source. */
-				allowMultipleSelection?: boolean
-	    
+		allowMultipleSelection?: boolean
+
 	    /** Whether to allow selection of people only, or people and groups. Must be one of peopleAndGroups or peopleOnly. */
-				chooseFromType?: string
-	    
+		chooseFromType?: string
+
 	    /** How to display the information about the person or group chosen. See below. */
-				displayAs?: string
-	    
+		displayAs?: string
+
 }
 export interface TextColumn {
 
 	    /** Whether to allow multiple lines of text. */
-				allowMultipleLines?: boolean
-	    
+		allowMultipleLines?: boolean
+
 	    /** Whether updates to this column should replace existing text, or append to it. */
-				appendChangesToExistingText?: boolean
-	    
+		appendChangesToExistingText?: boolean
+
 	    /** The size of the text box. */
-				linesForEditing?: number
-	    
+		linesForEditing?: number
+
 	    /** The maximum number of characters for the value. */
-				maxLength?: number
-	    
+		maxLength?: number
+
 	    /** The type of text being stored. Must be one of plain or richText */
-				textType?: string
-	    
+		textType?: string
+
 }
 export interface ContentTypeOrder {
 
 	    /** Whether this is the default Content Type */
-				default?: boolean
-	    
+		default?: boolean
+
 	    /** Specifies the position in which the Content Type appears in the selection UI. */
-				position?: number
-	    
+		position?: number
+
 }
 export interface Quota {
 
 	    /** Total space consumed by files in the recycle bin, in bytes. Read-only. */
-				deleted?: number
-	    
+		deleted?: number
+
 	    /** Total space remaining before reaching the quota limit, in bytes. Read-only. */
-				remaining?: number
-	    
+		remaining?: number
+
 	    /** Enumeration value that indicates the state of the storage space. Read-only. */
-				state?: string
-	    
+		state?: string
+
 	    /** Total allowed storage space, in bytes. Read-only. */
-				total?: number
-	    
+		total?: number
+
 	    /** Total space used, in bytes. Read-only. */
-				used?: number
-	    
+		used?: number
+
 }
 export interface SystemFacet {
 
@@ -8942,241 +9326,241 @@ export interface SystemFacet {
 export interface Audio {
 
 	    /** The title of the album for this audio file. */
-				album?: string
-	    
+		album?: string
+
 	    /** The artist named on the album for the audio file. */
-				albumArtist?: string
-	    
+		albumArtist?: string
+
 	    /** The performing artist for the audio file. */
-				artist?: string
-	    
+		artist?: string
+
 	    /** Bitrate expressed in kbps. */
-				bitrate?: number
-	    
+		bitrate?: number
+
 	    /** The name of the composer of the audio file. */
-				composers?: string
-	    
+		composers?: string
+
 	    /** Copyright information for the audio file. */
-				copyright?: string
-	    
+		copyright?: string
+
 	    /** The number of the disc this audio file came from. */
-				disc?: number
-	    
+		disc?: number
+
 	    /** The total number of discs in this album. */
-				discCount?: number
-	    
+		discCount?: number
+
 	    /** Duration of the audio file, expressed in milliseconds */
-				duration?: number
-	    
+		duration?: number
+
 	    /** The genre of this audio file. */
-				genre?: string
-	    
+		genre?: string
+
 	    /** Indicates if the file is protected with digital rights management. */
-				hasDrm?: boolean
-	    
+		hasDrm?: boolean
+
 	    /** Indicates if the file is encoded with a variable bitrate. */
-				isVariableBitrate?: boolean
-	    
+		isVariableBitrate?: boolean
+
 	    /** The title of the audio file. */
-				title?: string
-	    
+		title?: string
+
 	    /** The number of the track on the original disc for this audio file. */
-				track?: number
-	    
+		track?: number
+
 	    /** The total number of tracks on the original disc for this audio file. */
-				trackCount?: number
-	    
+		trackCount?: number
+
 	    /** The year the audio file was recorded. */
-				year?: number
-	    
+		year?: number
+
 }
 export interface Deleted {
 
 	    /** Represents the state of the deleted item. */
-				state?: string
-	    
+		state?: string
+
 }
 export interface File {
 
 	    /** Hashes of the file's binary content, if available. Read-only. */
-				hashes?: Hashes
-	    
+		hashes?: Hashes
+
 	    /** The MIME type for the file. This is determined by logic on the server and might not be the value provided when the file was uploaded. Read-only. */
-				mimeType?: string
-	    
-				processingMetadata?: boolean
-	    
+		mimeType?: string
+
+		processingMetadata?: boolean
+
 }
 export interface Hashes {
 
 	    /** The CRC32 value of the file (if available). Read-only. */
-				crc32Hash?: string
-	    
+		crc32Hash?: string
+
 	    /** A proprietary hash of the file that can be used to determine if the contents of the file have changed (if available). Read-only. */
-				quickXorHash?: string
-	    
+		quickXorHash?: string
+
 	    /** SHA1 hash for the contents of the file (if available). Read-only. */
-				sha1Hash?: string
-	    
+		sha1Hash?: string
+
 }
 export interface FileSystemInfo {
 
 	    /** The UTC date and time the file was created on a client. */
-				createdDateTime?: string
-	    
+		createdDateTime?: string
+
 	    /** The UTC date and time the file was last accessed. Available for the recent file list only. */
-				lastAccessedDateTime?: string
-	    
+		lastAccessedDateTime?: string
+
 	    /** The UTC date and time the file was last modified on a client. */
-				lastModifiedDateTime?: string
-	    
+		lastModifiedDateTime?: string
+
 }
 export interface Folder {
 
 	    /** Number of children contained immediately within this container. */
-				childCount?: number
-	    
+		childCount?: number
+
 	    /** A collection of properties defining the recommended view for the folder. */
-				view?: FolderView
-	    
+		view?: FolderView
+
 }
 export interface FolderView {
 
 	    /** The method by which the folder should be sorted. */
-				sortBy?: string
-	    
-				sortOrder?: string
-	    
+		sortBy?: string
+
+		sortOrder?: string
+
 	    /** The type of view that should be used to represent the folder. */
-				viewType?: string
-	    
+		viewType?: string
+
 }
 export interface Image {
 
 	    /** Optional. Height of the image, in pixels. Read-only. */
-				height?: number
-	    
+		height?: number
+
 	    /** Optional. Width of the image, in pixels. Read-only. */
-				width?: number
-	    
+		width?: number
+
 }
 export interface GeoCoordinates {
 
 	    /** Optional. The altitude (height), in feet,  above sea level for the item. Read-only. */
-				altitude?: number
-	    
+		altitude?: number
+
 	    /** Optional. The latitude, in decimal, for the item. Read-only. */
-				latitude?: number
-	    
+		latitude?: number
+
 	    /** Optional. The longitude, in decimal, for the item. Read-only. */
-				longitude?: number
-	    
+		longitude?: number
+
 }
 export interface Package {
 
-				type?: string
-	    
+		type?: string
+
 }
 export interface Photo {
 
 	    /** Camera manufacturer. Read-only. */
-				cameraMake?: string
-	    
+		cameraMake?: string
+
 	    /** Camera model. Read-only. */
-				cameraModel?: string
-	    
+		cameraModel?: string
+
 	    /** The denominator for the exposure time fraction from the camera. Read-only. */
-				exposureDenominator?: number
-	    
+		exposureDenominator?: number
+
 	    /** The numerator for the exposure time fraction from the camera. Read-only. */
-				exposureNumerator?: number
-	    
+		exposureNumerator?: number
+
 	    /** The F-stop value from the camera. Read-only. */
-				fNumber?: number
-	    
+		fNumber?: number
+
 	    /** The focal length from the camera. Read-only. */
-				focalLength?: number
-	    
+		focalLength?: number
+
 	    /** The ISO value from the camera. Read-only. */
-				iso?: number
-	    
+		iso?: number
+
 	    /** Represents the date and time the photo was taken. Read-only. */
-				takenDateTime?: string
-	    
+		takenDateTime?: string
+
 }
 export interface RemoteItem {
 
 	    /** Identity of the user, device, and application which created the item. Read-only. */
-				createdBy?: IdentitySet
-	    
+		createdBy?: IdentitySet
+
 	    /** Date and time of item creation. Read-only. */
-				createdDateTime?: string
-	    
+		createdDateTime?: string
+
 	    /** Indicates that the remote item is a file. Read-only. */
-				file?: File
-	    
+		file?: File
+
 	    /** Information about the remote item from the local file system. Read-only. */
-				fileSystemInfo?: FileSystemInfo
-	    
+		fileSystemInfo?: FileSystemInfo
+
 	    /** Indicates that the remote item is a folder. Read-only. */
-				folder?: Folder
-	    
+		folder?: Folder
+
 	    /** Unique identifier for the remote item in its drive. Read-only. */
-				id?: string
-	    
+		id?: string
+
 	    /** Identity of the user, device, and application which last modified the item. Read-only. */
-				lastModifiedBy?: IdentitySet
-	    
+		lastModifiedBy?: IdentitySet
+
 	    /** Date and time the item was last modified. Read-only. */
-				lastModifiedDateTime?: string
-	    
+		lastModifiedDateTime?: string
+
 	    /** Optional. Filename of the remote item. Read-only. */
-				name?: string
-	    
+		name?: string
+
 	    /** If present, indicates that this item is a package instead of a folder or file. Packages are treated like files in some contexts and folders in others. Read-only. */
-				package?: Package
-	    
+		package?: Package
+
 	    /** Properties of the parent of the remote item. Read-only. */
-				parentReference?: ItemReference
-	    
+		parentReference?: ItemReference
+
 	    /** Indicates that the item has been shared with others and provides information about the shared state of the item. Read-only. */
-				shared?: Shared
-	    
+		shared?: Shared
+
 	    /** Provides interop between items in OneDrive for Business and SharePoint with the full set of item identifiers. Read-only. */
-				sharepointIds?: SharepointIds
-	    
+		sharepointIds?: SharepointIds
+
 	    /** Size of the remote item. Read-only. */
-				size?: number
-	    
-				specialFolder?: SpecialFolder
-	    
+		size?: number
+
+		specialFolder?: SpecialFolder
+
 	    /** DAV compatible URL for the item. */
-				webDavUrl?: string
-	    
+		webDavUrl?: string
+
 	    /** URL that displays the resource in the browser. Read-only. */
-				webUrl?: string
-	    
+		webUrl?: string
+
 }
 export interface Shared {
 
 	    /** The identity of the owner of the shared item. Read-only. */
-				owner?: IdentitySet
-	    
+		owner?: IdentitySet
+
 	    /** Indicates the scope of how the item is shared: anonymous, organization, or users. Read-only. */
-				scope?: string
-	    
+		scope?: string
+
 	    /** The identity of the user who shared the item. Read-only. */
-				sharedBy?: IdentitySet
-	    
+		sharedBy?: IdentitySet
+
 	    /** The UTC date and time when the item was shared. Read-only. */
-				sharedDateTime?: string
-	    
+		sharedDateTime?: string
+
 }
 export interface SpecialFolder {
 
 	    /** The unique identifier for this item in the /drive/special collection */
-				name?: string
-	    
+		name?: string
+
 }
 export interface Root {
 
@@ -9184,245 +9568,245 @@ export interface Root {
 export interface SearchResult {
 
 	    /** A callback URL that can be used to record telemetry information. The application should issue a GET on this URL if the user interacts with this item to improve the quality of results. */
-				onClickTelemetryUrl?: string
-	    
+		onClickTelemetryUrl?: string
+
 }
 export interface Video {
 
 	    /** Number of audio bits per sample. */
-				audioBitsPerSample?: number
-	    
+		audioBitsPerSample?: number
+
 	    /** Number of audio channels. */
-				audioChannels?: number
-	    
+		audioChannels?: number
+
 	    /** Name of the audio format (AAC, MP3, etc.). */
-				audioFormat?: string
-	    
+		audioFormat?: string
+
 	    /** Number of audio samples per second. */
-				audioSamplesPerSecond?: number
-	    
+		audioSamplesPerSecond?: number
+
 	    /** Bit rate of the video in bits per second. */
-				bitrate?: number
-	    
+		bitrate?: number
+
 	    /** Duration of the file in milliseconds. */
-				duration?: number
-	    
+		duration?: number
+
 	    /** "Four character code" name of the video format. */
-				fourCC?: string
-	    
-				frameRate?: number
-	    
+		fourCC?: string
+
+		frameRate?: number
+
 	    /** Height of the video, in pixels. */
-				height?: number
-	    
+		height?: number
+
 	    /** Width of the video, in pixels. */
-				width?: number
-	    
+		width?: number
+
 }
 export interface ListInfo {
 
 	    /** If true, indicates that content types are enabled for this list. */
-				contentTypesEnabled?: boolean
-	    
+		contentTypesEnabled?: boolean
+
 	    /** If true, indicates that the list is not normally visible in the SharePoint user experience. */
-				hidden?: boolean
-	    
+		hidden?: boolean
+
 	    /** An enumerated value that represents the base list template used in creating the list. Possible values include documentLibrary, genericList, task, survey, announcements, contacts, and more. */
-				template?: string
-	    
+		template?: string
+
 }
 export interface ContentTypeInfo {
 
 	    /** The id of the content type. */
-				id?: string
-	    
+		id?: string
+
 }
 export interface SharingInvitation {
 
 	    /** The email address provided for the recipient of the sharing invitation. Read-only. */
-				email?: string
-	    
+		email?: string
+
 	    /** Provides information about who sent the invitation that created this permission, if that information is available. Read-only. */
-				invitedBy?: IdentitySet
-	    
-				redeemedBy?: string
-	    
+		invitedBy?: IdentitySet
+
+		redeemedBy?: string
+
 	    /** If true the recipient of the invitation needs to sign in in order to access the shared item. Read-only. */
-				signInRequired?: boolean
-	    
+		signInRequired?: boolean
+
 }
 export interface SharingLink {
 
 	    /** The app the link is associated with. */
-				application?: Identity
-	    
+		application?: Identity
+
 	    /** The scope of the link represented by this permission. Value anonymous indicates the link is usable by anyone, organization indicates the link is only usable for users signed into the same tenant. */
-				scope?: string
-	    
+		scope?: string
+
 	    /** The type of the link created. */
-				type?: string
-	    
+		type?: string
+
 	    /** A URL that opens the item in the browser on the OneDrive website. */
-				webUrl?: string
-	    
+		webUrl?: string
+
 }
 export interface SiteCollection {
 
 	    /** The hostname for the site collection. Read-only. */
-				hostname?: string
-	    
+		hostname?: string
+
 	    /** If present, indicates that this is a root site collection in SharePoint. Read-only. */
-				root?: Root
-	    
+		root?: Root
+
 }
 export interface Thumbnail {
 
-				content?: any
-	    
+		content?: any
+
 	    /** The height of the thumbnail, in pixels. */
-				height?: number
-	    
+		height?: number
+
 	    /** The unique identifier of the item that provided the thumbnail. This is only available when a folder thumbnail is requested. */
-				sourceItemId?: string
-	    
+		sourceItemId?: string
+
 	    /** The URL used to fetch the thumbnail content. */
-				url?: string
-	    
+		url?: string
+
 	    /** The width of the thumbnail, in pixels. */
-				width?: number
-	    
+		width?: number
+
 }
 export interface DriveItemUploadableProperties {
 
-				description?: string
-	    
-				fileSystemInfo?: FileSystemInfo
-	    
-				name?: string
-	    
+		description?: string
+
+		fileSystemInfo?: FileSystemInfo
+
+		name?: string
+
 }
 export interface DriveRecipient {
 
 	    /** The alias of the domain object, for cases where an email address is unavailable (e.g. security groups). */
-				alias?: string
-	    
+		alias?: string
+
 	    /** The email address for the recipient, if the recipient has an associated email address. */
-				email?: string
-	    
+		email?: string
+
 	    /** The unique identifier for the recipient in the directory. */
-				objectId?: string
-	    
+		objectId?: string
+
 }
 export interface UploadSession {
 
 	    /** The date and time in UTC that the upload session will expire. The complete file must be uploaded before this expiration time is reached. */
-				expirationDateTime?: string
-	    
+		expirationDateTime?: string
+
 	    /** A collection of byte ranges that the server is missing for the file. These ranges are zero indexed and of the format "start-end" (e.g. "0-26" to indicate the first 27 bytes of the file). */
-				nextExpectedRanges?: string[]
-	    
+		nextExpectedRanges?: string[]
+
 	    /** The URL endpoint that accepts PUT requests for byte ranges of the file. */
-				uploadUrl?: string
-	    
+		uploadUrl?: string
+
 }
 export interface WorkbookSessionInfo {
 
 	    /** Id of the workbook session. */
-				id?: string
-	    
+		id?: string
+
 	    /** true for persistent session. false for non-persistent session (view mode) */
-				persistChanges?: boolean
-	    
+		persistChanges?: boolean
+
 }
 export interface WorkbookFilterCriteria {
 
-				color?: string
-	    
-				criterion1?: string
-	    
-				criterion2?: string
-	    
-				dynamicCriteria: string
-	    
-				filterOn: string
-	    
-				icon?: WorkbookIcon
-	    
-				operator: string
-	    
-				values?: any
-	    
+		color?: string
+
+		criterion1?: string
+
+		criterion2?: string
+
+		dynamicCriteria?: string
+
+		filterOn?: string
+
+		icon?: WorkbookIcon
+
+		operator?: string
+
+		values?: any
+
 }
 export interface WorkbookIcon {
 
-				index: number
-	    
-				set: string
-	    
+		index?: number
+
+		set?: string
+
 }
 export interface WorkbookSortField {
 
-				ascending: boolean
-	    
-				color?: string
-	    
-				dataOption: string
-	    
-				icon?: WorkbookIcon
-	    
-				key: number
-	    
-				sortOn: string
-	    
+		ascending?: boolean
+
+		color?: string
+
+		dataOption?: string
+
+		icon?: WorkbookIcon
+
+		key?: number
+
+		sortOn?: string
+
 }
 export interface WorkbookWorksheetProtectionOptions {
 
-				allowAutoFilter: boolean
-	    
-				allowDeleteColumns: boolean
-	    
-				allowDeleteRows: boolean
-	    
-				allowFormatCells: boolean
-	    
-				allowFormatColumns: boolean
-	    
-				allowFormatRows: boolean
-	    
-				allowInsertColumns: boolean
-	    
-				allowInsertHyperlinks: boolean
-	    
-				allowInsertRows: boolean
-	    
-				allowPivotTables: boolean
-	    
-				allowSort: boolean
-	    
+		allowAutoFilter?: boolean
+
+		allowDeleteColumns?: boolean
+
+		allowDeleteRows?: boolean
+
+		allowFormatCells?: boolean
+
+		allowFormatColumns?: boolean
+
+		allowFormatRows?: boolean
+
+		allowInsertColumns?: boolean
+
+		allowInsertHyperlinks?: boolean
+
+		allowInsertRows?: boolean
+
+		allowPivotTables?: boolean
+
+		allowSort?: boolean
+
 }
 export interface WorkbookFilterDatetime {
 
-				date?: string
-	    
-				specificity: string
-	    
+		date?: string
+
+		specificity?: string
+
 }
 export interface WorkbookRangeReference {
 
-				address?: string
-	    
+		address?: string
+
 }
 export interface InvitedUserMessageInfo {
 
 	    /** Additional recipients the invitation message should be sent to. Currently only 1 additional recipient is supported. */
-				ccRecipients?: Recipient[]
-	    
+		ccRecipients?: Recipient[]
+
 	    /** The language you want to send the default message in. If the customizedMessageBody is specified, this property is ignored, and the message is sent using the customizedMessageBody. The language format should be in ISO 639. The default is en-US. */
-				messageLanguage?: string
-	    
+		messageLanguage?: string
+
 	    /** Customized message body you want to send if you don't want the default message. */
-				customizedMessageBody?: string
-	    
+		customizedMessageBody?: string
+
 }
 export interface PlannerAppliedCategories {
 
@@ -9433,50 +9817,50 @@ export interface PlannerAssignments {
 export interface PlannerExternalReference {
 
 	    /** A name alias to describe the reference. */
-				alias?: string
-	    
+		alias?: string
+
 	    /** Used to describe the type of the reference. Types include: PowerPoint, Word, Excel, Other. */
-				type?: string
-	    
+		type?: string
+
 	    /** Used to set the relative priority order in which the reference will be shown as a preview on the task. */
-				previewPriority?: string
-	    
+		previewPriority?: string
+
 	    /** Read-only. User ID by which this is last modified. */
-				lastModifiedBy?: IdentitySet
-	    
+		lastModifiedBy?: IdentitySet
+
 	    /** Read-only. Date and time at which this is last modified. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-				lastModifiedDateTime?: string
-	    
+		lastModifiedDateTime?: string
+
 }
 export interface PlannerChecklistItem {
 
 	    /** Value is true if the item is checked and false otherwise. */
-				isChecked?: boolean
-	    
+		isChecked?: boolean
+
 	    /** Title of the checklist item */
-				title?: string
-	    
+		title?: string
+
 	    /** Used to set the relative order of items in the checklist. The format is defined as outlined here. */
-				orderHint?: string
-	    
+		orderHint?: string
+
 	    /** Read-only. User ID by which this is last modified. */
-				lastModifiedBy?: IdentitySet
-	    
+		lastModifiedBy?: IdentitySet
+
 	    /** Read-only. Date and time at which this is last modified. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-				lastModifiedDateTime?: string
-	    
+		lastModifiedDateTime?: string
+
 }
 export interface PlannerAssignment {
 
 	    /** The identity of the user that performed the assignment of the task, i.e. the assignor. */
-				assignedBy?: IdentitySet
-	    
+		assignedBy?: IdentitySet
+
 	    /** The time at which the task was assigned. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z' */
-				assignedDateTime?: string
-	    
+		assignedDateTime?: string
+
 	    /** Hint used to order assignees in a task. The format is defined as outlined here. */
-				orderHint?: string
-	    
+		orderHint?: string
+
 }
 export interface PlannerExternalReferences {
 
@@ -9493,188 +9877,188 @@ export interface PlannerUserIds {
 export interface PlannerCategoryDescriptions {
 
 	    /** The label associated with Category 1 */
-				category1?: string
-	    
+		category1?: string
+
 	    /** The label associated with Category 2 */
-				category2?: string
-	    
+		category2?: string
+
 	    /** The label associated with Category 3 */
-				category3?: string
-	    
+		category3?: string
+
 	    /** The label associated with Category 4 */
-				category4?: string
-	    
+		category4?: string
+
 	    /** The label associated with Category 5 */
-				category5?: string
-	    
+		category5?: string
+
 	    /** The label associated with Category 6 */
-				category6?: string
-	    
+		category6?: string
+
 }
 export interface NotebookLinks {
 
 	    /** Opens the notebook in the OneNote native client if it's installed. */
-				oneNoteClientUrl?: ExternalLink
-	    
+		oneNoteClientUrl?: ExternalLink
+
 	    /** Opens the notebook in OneNote Online. */
-				oneNoteWebUrl?: ExternalLink
-	    
+		oneNoteWebUrl?: ExternalLink
+
 }
 export interface ExternalLink {
 
 	    /** The url of the link. */
-				href?: string
-	    
+		href?: string
+
 }
 export interface SectionLinks {
 
 	    /** Opens the section in the OneNote native client if it's installed. */
-				oneNoteClientUrl?: ExternalLink
-	    
+		oneNoteClientUrl?: ExternalLink
+
 	    /** Opens the section in OneNote Online. */
-				oneNoteWebUrl?: ExternalLink
-	    
+		oneNoteWebUrl?: ExternalLink
+
 }
 export interface PageLinks {
 
 	    /** Opens the page in the OneNote native client if it's installed. */
-				oneNoteClientUrl?: ExternalLink
-	    
+		oneNoteClientUrl?: ExternalLink
+
 	    /** Opens the page in OneNote Online. */
-				oneNoteWebUrl?: ExternalLink
-	    
+		oneNoteWebUrl?: ExternalLink
+
 }
 export interface OnenoteOperationError {
 
 	    /** The error code. */
-				code?: string
-	    
+		code?: string
+
 	    /** The error message. */
-				message?: string
-	    
+		message?: string
+
 }
 export interface Diagnostic {
 
-				message?: string
-	    
-				url?: string
-	    
+		message?: string
+
+		url?: string
+
 }
 export interface OnenotePatchContentCommand {
 
 	    /** The action to perform on the target element. Possible values are: replace, append, delete, insert, or prepend. */
-				action: OnenotePatchActionType
-	    
+		action?: OnenotePatchActionType
+
 	    /** The element to update. Must be the #<data-id> or the generated <id> of the element, or the body or title keyword. */
-				target: string
-	    
+		target?: string
+
 	    /** A string of well-formed HTML to add to the page, and any image or file binary data. If the content contains binary data, the request must be sent using the multipart/form-data content type with a "Commands" part. */
-				content?: string
-	    
+		content?: string
+
 	    /** The location to add the supplied content, relative to the target element. Possible values are: after (default) or before. */
-				position?: OnenotePatchInsertPosition
-	    
+		position?: OnenotePatchInsertPosition
+
 }
 export interface OnenotePagePreview {
 
-				previewText?: string
-	    
-				links?: OnenotePagePreviewLinks
-	    
+		previewText?: string
+
+		links?: OnenotePagePreviewLinks
+
 }
 export interface OnenotePagePreviewLinks {
 
-				previewImageUrl?: ExternalLink
-	    
+		previewImageUrl?: ExternalLink
+
 }
 export interface RecentNotebook {
 
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** The date and time when the notebook was last modified. The timestamp represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'. Read-only. */
-				lastAccessedTime?: string
-	    
+		lastAccessedTime?: string
+
 	    /** Links for opening the notebook. The oneNoteClientURL link opens the notebook in the OneNote client, if it's installed. The oneNoteWebURL link opens the notebook in OneNote Online. */
-				links?: RecentNotebookLinks
-	    
+		links?: RecentNotebookLinks
+
 	    /** The backend store where the Notebook resides, either OneDriveForBusiness or OneDrive. */
-				sourceService?: OnenoteSourceService
-	    
+		sourceService?: OnenoteSourceService
+
 }
 export interface RecentNotebookLinks {
 
 	    /** Opens the notebook in the OneNote native client if it's installed. */
-				oneNoteClientUrl?: ExternalLink
-	    
+		oneNoteClientUrl?: ExternalLink
+
 	    /** Opens the notebook in OneNote Online. */
-				oneNoteWebUrl?: ExternalLink
-	    
+		oneNoteWebUrl?: ExternalLink
+
 }
 export interface Report {
 
 	    /** Not yet documented */
-				content?: any
-	    
+		content?: any
+
 }
 export interface EducationStudent {
 
 	    /** Year the student is graduating from the school. */
-				graduationYear?: string
-	    
+		graduationYear?: string
+
 	    /** Current grade level of the student. */
-				grade?: string
-	    
+		grade?: string
+
 	    /** Birth date of the student. */
-				birthDate?: string
-	    
+		birthDate?: string
+
 	    /** Possible values are: female, male, other, unkownFutureValue. */
-				gender?: EducationGender
-	    
+		gender?: EducationGender
+
 	    /** Student Number. */
-				studentNumber?: string
-	    
+		studentNumber?: string
+
 	    /** ID of the student in the source system. */
-				externalId?: string
-	    
+		externalId?: string
+
 }
 export interface EducationRelatedContact {
 
-				id?: string
-	    
-				displayName: string
-	    
-				emailAddress?: string
-	    
-				mobilePhone?: string
-	    
-				relationship: EducationContactRelationship
-	    
-				accessConsent?: boolean
-	    
+		id?: string
+
+		displayName?: string
+
+		emailAddress?: string
+
+		mobilePhone?: string
+
+		relationship?: EducationContactRelationship
+
+		accessConsent?: boolean
+
 }
 export interface EducationTeacher {
 
 	    /** Teacher number. */
-				teacherNumber?: string
-	    
+		teacherNumber?: string
+
 	    /** ID of the teacher in the source system. */
-				externalId?: string
-	    
+		externalId?: string
+
 }
 export interface EducationTerm {
 
 	    /** ID of term in the syncing system. */
-				externalId?: string
-	    
+		externalId?: string
+
 	    /** Start of the term. */
-				startDate?: string
-	    
+		startDate?: string
+
 	    /** End of the term. */
-				endDate?: string
-	    
+		endDate?: string
+
 	    /** Display name of the term. */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface DeviceAndAppManagementAssignmentTarget {
 
@@ -9685,35 +10069,35 @@ export interface MobileAppAssignmentSettings {
 export interface MimeContent {
 
 	    /** Indicates the content mime type. */
-				type?: string
-	    
+		type?: string
+
 	    /** The byte array that contains the actual content. */
-				value?: number
-	    
+		value?: number
+
 }
 export interface FileEncryptionInfo {
 
 	    /** The key used to encrypt the file content. */
-				encryptionKey?: number
-	    
+		encryptionKey?: number
+
 	    /** The initialization vector used for the encryption algorithm. */
-				initializationVector?: number
-	    
+		initializationVector?: number
+
 	    /** The hash of the encrypted file content + IV (content hash). */
-				mac?: number
-	    
+		mac?: number
+
 	    /** The key used to get mac. */
-				macKey?: number
-	    
+		macKey?: number
+
 	    /** The the profile identifier. */
-				profileIdentifier?: string
-	    
+		profileIdentifier?: string
+
 	    /** The file digest prior to encryption. */
-				fileDigest?: number
-	    
+		fileDigest?: number
+
 	    /** The file digest algorithm. */
-				fileDigestAlgorithm?: string
-	    
+		fileDigestAlgorithm?: string
+
 }
 export interface AllLicensedUsersAssignmentTarget extends DeviceAndAppManagementAssignmentTarget {
 
@@ -9721,8 +10105,8 @@ export interface AllLicensedUsersAssignmentTarget extends DeviceAndAppManagement
 export interface GroupAssignmentTarget extends DeviceAndAppManagementAssignmentTarget {
 
 	    /** The group Id that is the target of the assignment. */
-				groupId?: string
-	    
+		groupId?: string
+
 }
 export interface ExclusionGroupAssignmentTarget extends GroupAssignmentTarget {
 
@@ -9733,767 +10117,767 @@ export interface AllDevicesAssignmentTarget extends DeviceAndAppManagementAssign
 export interface IosLobAppAssignmentSettings extends MobileAppAssignmentSettings {
 
 	    /** The VPN Configuration Id to apply for this app. */
-				vpnConfigurationId?: string
-	    
+		vpnConfigurationId?: string
+
 }
 export interface IosStoreAppAssignmentSettings extends MobileAppAssignmentSettings {
 
 	    /** The VPN Configuration Id to apply for this app. */
-				vpnConfigurationId?: string
-	    
+		vpnConfigurationId?: string
+
 }
 export interface IosVppAppAssignmentSettings extends MobileAppAssignmentSettings {
 
 	    /** Whether or not to use device licensing. */
-				useDeviceLicensing: boolean
-	    
+		useDeviceLicensing?: boolean
+
 	    /** The VPN Configuration Id to apply for this app. */
-				vpnConfigurationId?: string
-	    
+		vpnConfigurationId?: string
+
 }
 export interface MicrosoftStoreForBusinessAppAssignmentSettings extends MobileAppAssignmentSettings {
 
 	    /** Whether or not to use device execution context for Microsoft Store for Business mobile app. */
-				useDeviceContext: boolean
-	    
+		useDeviceContext?: boolean
+
 }
 export interface AndroidMinimumOperatingSystem {
 
 	    /** Version 4.0 or later. */
-				v4_0: boolean
-	    
+		v4_0?: boolean
+
 	    /** Version 4.0.3 or later. */
-				v4_0_3: boolean
-	    
+		v4_0_3?: boolean
+
 	    /** Version 4.1 or later. */
-				v4_1: boolean
-	    
+		v4_1?: boolean
+
 	    /** Version 4.2 or later. */
-				v4_2: boolean
-	    
+		v4_2?: boolean
+
 	    /** Version 4.3 or later. */
-				v4_3: boolean
-	    
+		v4_3?: boolean
+
 	    /** Version 4.4 or later. */
-				v4_4: boolean
-	    
+		v4_4?: boolean
+
 	    /** Version 5.0 or later. */
-				v5_0: boolean
-	    
+		v5_0?: boolean
+
 	    /** Version 5.1 or later. */
-				v5_1: boolean
-	    
+		v5_1?: boolean
+
 }
 export interface IosDeviceType {
 
 	    /** Whether the app should run on iPads. */
-				iPad: boolean
-	    
+		iPad?: boolean
+
 	    /** Whether the app should run on iPhones and iPods. */
-				iPhoneAndIPod: boolean
-	    
+		iPhoneAndIPod?: boolean
+
 }
 export interface IosMinimumOperatingSystem {
 
 	    /** Version 8.0 or later. */
-				v8_0: boolean
-	    
+		v8_0?: boolean
+
 	    /** Version 9.0 or later. */
-				v9_0: boolean
-	    
+		v9_0?: boolean
+
 	    /** Version 10.0 or later. */
-				v10_0: boolean
-	    
+		v10_0?: boolean
+
 	    /** Version 11.0 or later. */
-				v11_0: boolean
-	    
+		v11_0?: boolean
+
 }
 export interface WindowsMinimumOperatingSystem {
 
 	    /** Windows version 8.0 or later. */
-				v8_0: boolean
-	    
+		v8_0?: boolean
+
 	    /** Windows version 8.1 or later. */
-				v8_1: boolean
-	    
+		v8_1?: boolean
+
 	    /** Windows version 10.0 or later. */
-				v10_0: boolean
-	    
+		v10_0?: boolean
+
 }
 export interface VppLicensingType {
 
 	    /** Whether the program supports the user licensing type. */
-				supportsUserLicensing: boolean
-	    
+		supportsUserLicensing?: boolean
+
 	    /** Whether the program supports the device licensing type. */
-				supportsDeviceLicensing: boolean
-	    
+		supportsDeviceLicensing?: boolean
+
 }
 export interface AppConfigurationSettingItem {
 
 	    /** app configuration key. */
-				appConfigKey: string
-	    
+		appConfigKey?: string
+
 	    /** app configuration key type. Possible values are: stringType, integerType, realType, booleanType, tokenType. */
-				appConfigKeyType: MdmAppConfigKeyType
-	    
+		appConfigKeyType?: MdmAppConfigKeyType
+
 	    /** app configuration key value. */
-				appConfigKeyValue: string
-	    
+		appConfigKeyValue?: string
+
 }
 export interface DeviceManagementSettings {
 
 	    /** The number of days a device is allowed to go without checking in to remain compliant. Valid values 0 to 120 */
-				deviceComplianceCheckinThresholdDays: number
-	    
+		deviceComplianceCheckinThresholdDays?: number
+
 	    /** Is feature enabled or not for scheduled action for rule. */
-				isScheduledActionEnabled: boolean
-	    
+		isScheduledActionEnabled?: boolean
+
 	    /** Device should be noncompliant when there is no compliance policy targeted when this is true */
-				secureByDefault: boolean
-	    
+		secureByDefault?: boolean
+
 }
 export interface IntuneBrand {
 
 	    /** Company/organization name that is displayed to end users. */
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** Name of the person/organization responsible for IT support. */
-				contactITName?: string
-	    
+		contactITName?: string
+
 	    /** Phone number of the person/organization responsible for IT support. */
-				contactITPhoneNumber?: string
-	    
+		contactITPhoneNumber?: string
+
 	    /** Email address of the person/organization responsible for IT support. */
-				contactITEmailAddress?: string
-	    
+		contactITEmailAddress?: string
+
 	    /** Text comments regarding the person/organization responsible for IT support. */
-				contactITNotes?: string
-	    
-	    /** URL to the company/organization’s privacy policy. */
-				privacyUrl?: string
-	    
-	    /** URL to the company/organization’s IT helpdesk site. */
-				onlineSupportSiteUrl?: string
-	    
-	    /** Display name of the company/organization’s IT helpdesk site. */
-				onlineSupportSiteName?: string
-	    
+		contactITNotes?: string
+
+	    /** URL to the company/organization's privacy policy. */
+		privacyUrl?: string
+
+	    /** URL to the company/organization's IT helpdesk site. */
+		onlineSupportSiteUrl?: string
+
+	    /** Display name of the company/organization's IT helpdesk site. */
+		onlineSupportSiteName?: string
+
 	    /** Primary theme color used in the Company Portal applications and web portal. */
-				themeColor?: RgbColor
-	    
+		themeColor?: RgbColor
+
 	    /** Boolean that represents whether the administrator-supplied logo images are shown or not shown. */
-				showLogo: boolean
-	    
+		showLogo?: boolean
+
 	    /** Logo image displayed in Company Portal apps which have a light background behind the logo. */
-				lightBackgroundLogo?: MimeContent
-	    
+		lightBackgroundLogo?: MimeContent
+
 	    /** Logo image displayed in Company Portal apps which have a dark background behind the logo. */
-				darkBackgroundLogo?: MimeContent
-	    
+		darkBackgroundLogo?: MimeContent
+
 	    /** Boolean that represents whether the administrator-supplied display name will be shown next to the logo image. */
-				showNameNextToLogo: boolean
-	    
+		showNameNextToLogo?: boolean
+
 	    /** Boolean that represents whether the administrator-supplied display name will be shown next to the logo image. */
-				showDisplayNameNextToLogo: boolean
-	    
+		showDisplayNameNextToLogo?: boolean
+
 }
 export interface RgbColor {
 
 	    /** Red value */
-				r: number
-	    
+		r?: number
+
 	    /** Green value */
-				g: number
-	    
+		g?: number
+
 	    /** Blue value */
-				b: number
-	    
+		b?: number
+
 }
 export interface DeviceActionResult {
 
 	    /** Action name */
-				actionName?: string
-	    
+		actionName?: string
+
 	    /** State of the action. Possible values are: none, pending, canceled, active, done, failed, notSupported. */
-				actionState: ActionState
-	    
+		actionState?: ActionState
+
 	    /** Time the action was initiated */
-				startDateTime: string
-	    
+		startDateTime?: string
+
 	    /** Time the action state was last updated */
-				lastUpdatedDateTime: string
-	    
+		lastUpdatedDateTime?: string
+
 }
 export interface ConfigurationManagerClientEnabledFeatures {
 
 	    /** Whether inventory is managed by Intune */
-				inventory: boolean
-	    
+		inventory?: boolean
+
 	    /** Whether modern application is managed by Intune */
-				modernApps: boolean
-	    
+		modernApps?: boolean
+
 	    /** Whether resource access is managed by Intune */
-				resourceAccess: boolean
-	    
+		resourceAccess?: boolean
+
 	    /** Whether device configuration is managed by Intune */
-				deviceConfiguration: boolean
-	    
+		deviceConfiguration?: boolean
+
 	    /** Whether compliance policy is managed by Intune */
-				compliancePolicy: boolean
-	    
+		compliancePolicy?: boolean
+
 	    /** Whether Windows Update for Business is managed by Intune */
-				windowsUpdateForBusiness: boolean
-	    
+		windowsUpdateForBusiness?: boolean
+
 }
 export interface DeviceHealthAttestationState {
 
 	    /** The Timestamp of the last update. */
-				lastUpdateDateTime?: string
-	    
+		lastUpdateDateTime?: string
+
 	    /** The DHA report version. (Namespace version) */
-				contentNamespaceUrl?: string
-	    
+		contentNamespaceUrl?: string
+
 	    /** The DHA report version. (Namespace version) */
-				deviceHealthAttestationStatus?: string
-	    
+		deviceHealthAttestationStatus?: string
+
 	    /** The HealthAttestation state schema version */
-				contentVersion?: string
-	    
+		contentVersion?: string
+
 	    /** The DateTime when device was evaluated or issued to MDM */
-				issuedDateTime: string
-	    
+		issuedDateTime?: string
+
 	    /** TWhen an Attestation Identity Key (AIK) is present on a device, it indicates that the device has an endorsement key (EK) certificate. */
-				attestationIdentityKey?: string
-	    
+		attestationIdentityKey?: string
+
 	    /** The number of times a PC device has hibernated or resumed */
-				resetCount: number
-	    
+		resetCount?: number
+
 	    /** The number of times a PC device has rebooted */
-				restartCount: number
-	    
+		restartCount?: number
+
 	    /** DEP Policy defines a set of hardware and software technologies that perform additional checks on memory */
-				dataExcutionPolicy?: string
-	    
+		dataExcutionPolicy?: string
+
 	    /** On or Off of BitLocker Drive Encryption */
-				bitLockerStatus?: string
-	    
+		bitLockerStatus?: string
+
 	    /** The version of the Boot Manager */
-				bootManagerVersion?: string
-	    
+		bootManagerVersion?: string
+
 	    /** The version of the Boot Manager */
-				codeIntegrityCheckVersion?: string
-	    
+		codeIntegrityCheckVersion?: string
+
 	    /** When Secure Boot is enabled, the core components must have the correct cryptographic signatures */
-				secureBoot?: string
-	    
+		secureBoot?: string
+
 	    /** When bootDebugging is enabled, the device is used in development and testing */
-				bootDebugging?: string
-	    
+		bootDebugging?: string
+
 	    /** When operatingSystemKernelDebugging is enabled, the device is used in development and testing */
-				operatingSystemKernelDebugging?: string
-	    
+		operatingSystemKernelDebugging?: string
+
 	    /** When code integrity is enabled, code execution is restricted to integrity verified code */
-				codeIntegrity?: string
-	    
+		codeIntegrity?: string
+
 	    /** When test signing is allowed, the device does not enforce signature validation during boot */
-				testSigning?: string
-	    
+		testSigning?: string
+
 	    /** Safe mode is a troubleshooting option for Windows that starts your computer in a limited state */
-				safeMode?: string
-	    
+		safeMode?: string
+
 	    /** Operating system running with limited services that is used to prepare a computer for Windows */
-				windowsPE?: string
-	    
+		windowsPE?: string
+
 	    /** ELAM provides protection for the computers in your network when they start up */
-				earlyLaunchAntiMalwareDriverProtection?: string
-	    
+		earlyLaunchAntiMalwareDriverProtection?: string
+
 	    /** VSM is a container that protects high value assets from a compromised kernel */
-				virtualSecureMode?: string
-	    
+		virtualSecureMode?: string
+
 	    /** Informational attribute that identifies the HASH algorithm that was used by TPM */
-				pcrHashAlgorithm?: string
-	    
+		pcrHashAlgorithm?: string
+
 	    /** The security version number of the Boot Application */
-				bootAppSecurityVersion?: string
-	    
+		bootAppSecurityVersion?: string
+
 	    /** The security version number of the Boot Application */
-				bootManagerSecurityVersion?: string
-	    
+		bootManagerSecurityVersion?: string
+
 	    /** The security version number of the Boot Application */
-				tpmVersion?: string
-	    
+		tpmVersion?: string
+
 	    /** The measurement that is captured in PCR[0] */
-				pcr0?: string
-	    
+		pcr0?: string
+
 	    /** Fingerprint of the Custom Secure Boot Configuration Policy */
-				secureBootConfigurationPolicyFingerPrint?: string
-	    
+		secureBootConfigurationPolicyFingerPrint?: string
+
 	    /** The Code Integrity policy that is controlling the security of the boot environment */
-				codeIntegrityPolicy?: string
-	    
+		codeIntegrityPolicy?: string
+
 	    /** The Boot Revision List that was loaded during initial boot on the attested device */
-				bootRevisionListInfo?: string
-	    
+		bootRevisionListInfo?: string
+
 	    /** The Operating System Revision List that was loaded during initial boot on the attested device */
-				operatingSystemRevListInfo?: string
-	    
+		operatingSystemRevListInfo?: string
+
 	    /** This attribute appears if DHA-Service detects an integrity issue */
-				healthStatusMismatchInfo?: string
-	    
+		healthStatusMismatchInfo?: string
+
 	    /** This attribute indicates if DHA is supported for the device */
-				healthAttestationSupportedStatus?: string
-	    
+		healthAttestationSupportedStatus?: string
+
 }
 export interface UpdateWindowsDeviceAccountActionParameter {
 
 	    /** Not yet documented */
-				deviceAccount?: WindowsDeviceAccount
-	    
+		deviceAccount?: WindowsDeviceAccount
+
 	    /** Not yet documented */
-				passwordRotationEnabled?: boolean
-	    
+		passwordRotationEnabled?: boolean
+
 	    /** Not yet documented */
-				calendarSyncEnabled?: boolean
-	    
+		calendarSyncEnabled?: boolean
+
 	    /** Not yet documented */
-				deviceAccountEmail?: string
-	    
+		deviceAccountEmail?: string
+
 	    /** Not yet documented */
-				exchangeServer?: string
-	    
+		exchangeServer?: string
+
 	    /** Not yet documented */
-				sessionInitiationProtocalAddress?: string
-	    
+		sessionInitiationProtocalAddress?: string
+
 }
 export interface WindowsDeviceAccount {
 
 	    /** Not yet documented */
-				password?: string
-	    
+		password?: string
+
 }
 export interface WindowsDefenderScanActionResult extends DeviceActionResult {
 
 	    /** Scan type either full scan or quick scan */
-				scanType?: string
-	    
+		scanType?: string
+
 }
 export interface DeleteUserFromSharedAppleDeviceActionResult extends DeviceActionResult {
 
 	    /** User principal name of the user to be deleted */
-				userPrincipalName?: string
-	    
+		userPrincipalName?: string
+
 }
 export interface DeviceGeoLocation {
 
 	    /** Time at which location was recorded, relative to UTC */
-				lastCollectedDateTime: string
-	    
+		lastCollectedDateTime?: string
+
 	    /** Longitude coordinate of the device's location */
-				longitude: number
-	    
+		longitude?: number
+
 	    /** Latitude coordinate of the device's location */
-				latitude: number
-	    
+		latitude?: number
+
 	    /** Altitude, given in meters above sea level */
-				altitude: number
-	    
+		altitude?: number
+
 	    /** Accuracy of longitude and latitude in meters */
-				horizontalAccuracy: number
-	    
+		horizontalAccuracy?: number
+
 	    /** Accuracy of altitude in meters */
-				verticalAccuracy: number
-	    
+		verticalAccuracy?: number
+
 	    /** Heading in degrees from true north */
-				heading: number
-	    
+		heading?: number
+
 	    /** Speed the device is traveling in meters per second */
-				speed: number
-	    
+		speed?: number
+
 }
 export interface LocateDeviceActionResult extends DeviceActionResult {
 
 	    /** device location */
-				deviceLocation?: DeviceGeoLocation
-	    
+		deviceLocation?: DeviceGeoLocation
+
 }
 export interface RemoteLockActionResult extends DeviceActionResult {
 
 	    /** Pin to unlock the client */
-				unlockPin?: string
-	    
+		unlockPin?: string
+
 }
 export interface ResetPasscodeActionResult extends DeviceActionResult {
 
 	    /** Newly generated passcode for the device */
-				passcode?: string
-	    
+		passcode?: string
+
 }
 export interface DeviceOperatingSystemSummary {
 
 	    /** Number of android device count. */
-				androidCount: number
-	    
+		androidCount?: number
+
 	    /** Number of iOS device count. */
-				iosCount: number
-	    
+		iosCount?: number
+
 	    /** Number of Mac OS X device count. */
-				macOSCount: number
-	    
+		macOSCount?: number
+
 	    /** Number of Windows mobile device count. */
-				windowsMobileCount: number
-	    
+		windowsMobileCount?: number
+
 	    /** Number of Windows device count. */
-				windowsCount: number
-	    
+		windowsCount?: number
+
 	    /** Number of unknown device count. */
-				unknownCount: number
-	    
+		unknownCount?: number
+
 }
 export interface DeviceExchangeAccessStateSummary {
 
 	    /** Total count of devices with Exchange Access State: Allowed. */
-				allowedDeviceCount: number
-	    
+		allowedDeviceCount?: number
+
 	    /** Total count of devices with Exchange Access State: Blocked. */
-				blockedDeviceCount: number
-	    
+		blockedDeviceCount?: number
+
 	    /** Total count of devices with Exchange Access State: Quarantined. */
-				quarantinedDeviceCount: number
-	    
+		quarantinedDeviceCount?: number
+
 	    /** Total count of devices with Exchange Access State: Unknown. */
-				unknownDeviceCount: number
-	    
+		unknownDeviceCount?: number
+
 	    /** Total count of devices for which no Exchange Access State could be found. */
-				unavailableDeviceCount: number
-	    
+		unavailableDeviceCount?: number
+
 }
 export interface WindowsDeviceADAccount extends WindowsDeviceAccount {
 
 	    /** Not yet documented */
-				domainName?: string
-	    
+		domainName?: string
+
 	    /** Not yet documented */
-				userName?: string
-	    
+		userName?: string
+
 }
 export interface WindowsDeviceAzureADAccount extends WindowsDeviceAccount {
 
 	    /** Not yet documented */
-				userPrincipalName?: string
-	    
+		userPrincipalName?: string
+
 }
 export interface AppListItem {
 
 	    /** The application name */
-				name: string
-	    
+		name?: string
+
 	    /** The publisher of the application */
-				publisher?: string
-	    
+		publisher?: string
+
 	    /** The Store URL of the application */
-				appStoreUrl?: string
-	    
+		appStoreUrl?: string
+
 	    /** The application or bundle identifier of the application */
-				appId?: string
-	    
+		appId?: string
+
 }
 export interface OmaSetting {
 
 	    /** Display Name. */
-				displayName: string
-	    
+		displayName?: string
+
 	    /** Description. */
-				description?: string
-	    
+		description?: string
+
 	    /** OMA. */
-				omaUri: string
-	    
+		omaUri?: string
+
 }
 export interface OmaSettingInteger extends OmaSetting {
 
 	    /** Value. */
-				value: number
-	    
+		value?: number
+
 }
 export interface OmaSettingFloatingPoint extends OmaSetting {
 
 	    /** Value. */
-				value: number
-	    
+		value?: number
+
 }
 export interface OmaSettingString extends OmaSetting {
 
 	    /** Value. */
-				value: string
-	    
+		value?: string
+
 }
 export interface OmaSettingDateTime extends OmaSetting {
 
 	    /** Value. */
-				value: string
-	    
+		value?: string
+
 }
 export interface OmaSettingStringXml extends OmaSetting {
 
 	    /** File name associated with the Value property (.xml). */
-				fileName?: string
-	    
+		fileName?: string
+
 	    /** Value. (UTF8 encoded byte array) */
-				value: number
-	    
+		value?: number
+
 }
 export interface OmaSettingBoolean extends OmaSetting {
 
 	    /** Value. */
-				value: boolean
-	    
+		value?: boolean
+
 }
 export interface OmaSettingBase64 extends OmaSetting {
 
 	    /** File name associated with the Value property (.cer */
-				fileName?: string
-	    
+		fileName?: string
+
 	    /** Value. (Base64 encoded string) */
-				value: string
-	    
+		value?: string
+
 }
 export interface MediaContentRatingAustralia {
 
 	    /** Movies rating selected for Australia. Possible values are: allAllowed, allBlocked, general, parentalGuidance, mature, agesAbove15, agesAbove18. */
-				movieRating: RatingAustraliaMoviesType
-	    
+		movieRating?: RatingAustraliaMoviesType
+
 	    /** TV rating selected for Australia. Possible values are: allAllowed, allBlocked, preschoolers, children, general, parentalGuidance, mature, agesAbove15, agesAbove15AdultViolence. */
-				tvRating: RatingAustraliaTelevisionType
-	    
+		tvRating?: RatingAustraliaTelevisionType
+
 }
 export interface MediaContentRatingCanada {
 
 	    /** Movies rating selected for Canada. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove14, agesAbove18, restricted. */
-				movieRating: RatingCanadaMoviesType
-	    
+		movieRating?: RatingCanadaMoviesType
+
 	    /** TV rating selected for Canada. Possible values are: allAllowed, allBlocked, children, childrenAbove8, general, parentalGuidance, agesAbove14, agesAbove18. */
-				tvRating: RatingCanadaTelevisionType
-	    
+		tvRating?: RatingCanadaTelevisionType
+
 }
 export interface MediaContentRatingFrance {
 
 	    /** Movies rating selected for France. Possible values are: allAllowed, allBlocked, agesAbove10, agesAbove12, agesAbove16, agesAbove18. */
-				movieRating: RatingFranceMoviesType
-	    
+		movieRating?: RatingFranceMoviesType
+
 	    /** TV rating selected for France. Possible values are: allAllowed, allBlocked, agesAbove10, agesAbove12, agesAbove16, agesAbove18. */
-				tvRating: RatingFranceTelevisionType
-	    
+		tvRating?: RatingFranceTelevisionType
+
 }
 export interface MediaContentRatingGermany {
 
 	    /** Movies rating selected for Germany. Possible values are: allAllowed, allBlocked, general, agesAbove6, agesAbove12, agesAbove16, adults. */
-				movieRating: RatingGermanyMoviesType
-	    
+		movieRating?: RatingGermanyMoviesType
+
 	    /** TV rating selected for Germany. Possible values are: allAllowed, allBlocked, general, agesAbove6, agesAbove12, agesAbove16, adults. */
-				tvRating: RatingGermanyTelevisionType
-	    
+		tvRating?: RatingGermanyTelevisionType
+
 }
 export interface MediaContentRatingIreland {
 
 	    /** Movies rating selected for Ireland. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove12, agesAbove15, agesAbove16, adults. */
-				movieRating: RatingIrelandMoviesType
-	    
+		movieRating?: RatingIrelandMoviesType
+
 	    /** TV rating selected for Ireland. Possible values are: allAllowed, allBlocked, general, children, youngAdults, parentalSupervision, mature. */
-				tvRating: RatingIrelandTelevisionType
-	    
+		tvRating?: RatingIrelandTelevisionType
+
 }
 export interface MediaContentRatingJapan {
 
 	    /** Movies rating selected for Japan. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove15, agesAbove18. */
-				movieRating: RatingJapanMoviesType
-	    
+		movieRating?: RatingJapanMoviesType
+
 	    /** TV rating selected for Japan. Possible values are: allAllowed, allBlocked, explicitAllowed. */
-				tvRating: RatingJapanTelevisionType
-	    
+		tvRating?: RatingJapanTelevisionType
+
 }
 export interface MediaContentRatingNewZealand {
 
 	    /** Movies rating selected for New Zealand. Possible values are: allAllowed, allBlocked, general, parentalGuidance, mature, agesAbove13, agesAbove15, agesAbove16, agesAbove18, restricted, agesAbove16Restricted. */
-				movieRating: RatingNewZealandMoviesType
-	    
+		movieRating?: RatingNewZealandMoviesType
+
 	    /** TV rating selected for New Zealand. Possible values are: allAllowed, allBlocked, general, parentalGuidance, adults. */
-				tvRating: RatingNewZealandTelevisionType
-	    
+		tvRating?: RatingNewZealandTelevisionType
+
 }
 export interface MediaContentRatingUnitedKingdom {
 
 	    /** Movies rating selected for United Kingdom. Possible values are: allAllowed, allBlocked, general, universalChildren, parentalGuidance, agesAbove12Video, agesAbove12Cinema, agesAbove15, adults. */
-				movieRating: RatingUnitedKingdomMoviesType
-	    
+		movieRating?: RatingUnitedKingdomMoviesType
+
 	    /** TV rating selected for United Kingdom. Possible values are: allAllowed, allBlocked, caution. */
-				tvRating: RatingUnitedKingdomTelevisionType
-	    
+		tvRating?: RatingUnitedKingdomTelevisionType
+
 }
 export interface MediaContentRatingUnitedStates {
 
 	    /** Movies rating selected for United States. Possible values are: allAllowed, allBlocked, general, parentalGuidance, parentalGuidance13, restricted, adults. */
-				movieRating: RatingUnitedStatesMoviesType
-	    
+		movieRating?: RatingUnitedStatesMoviesType
+
 	    /** TV rating selected for United States. Possible values are: allAllowed, allBlocked, childrenAll, childrenAbove7, general, parentalGuidance, childrenAbove14, adults. */
-				tvRating: RatingUnitedStatesTelevisionType
-	    
+		tvRating?: RatingUnitedStatesTelevisionType
+
 }
 export interface IosNetworkUsageRule {
 
 	    /** Information about the managed apps that this rule is going to apply to. This collection can contain a maximum of 500 elements. */
-				managedApps?: AppListItem[]
-	    
+		managedApps?: AppListItem[]
+
 	    /** If set to true, corresponding managed apps will not be allowed to use cellular data when roaming. */
-				cellularDataBlockWhenRoaming: boolean
-	    
+		cellularDataBlockWhenRoaming?: boolean
+
 	    /** If set to true, corresponding managed apps will not be allowed to use cellular data at any time. */
-				cellularDataBlocked: boolean
-	    
+		cellularDataBlocked?: boolean
+
 }
 export interface IosHomeScreenItem {
 
 	    /** Name of the app */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface IosHomeScreenPage {
 
 	    /** Name of the page */
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** A list of apps and folders to appear on a page. This collection can contain a maximum of 500 elements. */
-				icons: IosHomeScreenItem[]
-	    
+		icons?: IosHomeScreenItem[]
+
 }
 export interface IosNotificationSettings {
 
 	    /** Bundle id of app to which to apply these notification settings. */
-				bundleID: string
-	    
+		bundleID?: string
+
 	    /** Application name to be associated with the bundleID. */
-				appName?: string
-	    
+		appName?: string
+
 	    /** Publisher to be associated with the bundleID. */
-				publisher?: string
-	    
+		publisher?: string
+
 	    /** Indicates whether notifications are allowed for this app. */
-				enabled?: boolean
-	    
+		enabled?: boolean
+
 	    /** Indicates whether notifications can be shown in notification center. */
-				showInNotificationCenter?: boolean
-	    
+		showInNotificationCenter?: boolean
+
 	    /** Indicates whether notifications can be shown on the lock screen. */
-				showOnLockScreen?: boolean
-	    
+		showOnLockScreen?: boolean
+
 	    /** Indicates the type of alert for notifications for this app. Possible values are: deviceDefault, banner, modal, none. */
-				alertType: IosNotificationAlertType
-	    
+		alertType?: IosNotificationAlertType
+
 	    /** Indicates whether badges are allowed for this app. */
-				badgesEnabled?: boolean
-	    
+		badgesEnabled?: boolean
+
 	    /** Indicates whether sounds are allowed for this app. */
-				soundsEnabled?: boolean
-	    
+		soundsEnabled?: boolean
+
 }
 export interface IosHomeScreenFolder extends IosHomeScreenItem {
 
 	    /** Pages of Home Screen Layout Icons which must be Application Type. This collection can contain a maximum of 500 elements. */
-				pages: IosHomeScreenFolderPage[]
-	    
+		pages?: IosHomeScreenFolderPage[]
+
 }
 export interface IosHomeScreenFolderPage {
 
 	    /** Name of the folder page */
-				displayName?: string
-	    
+		displayName?: string
+
 	    /** A list of apps to appear on a page within a folder. This collection can contain a maximum of 500 elements. */
-				apps: IosHomeScreenApp[]
-	    
+		apps?: IosHomeScreenApp[]
+
 }
 export interface IosHomeScreenApp extends IosHomeScreenItem {
 
 	    /** BundleID of app */
-				bundleID: string
-	    
+		bundleID?: string
+
 }
 export interface WindowsFirewallNetworkProfile {
 
 	    /** Turn on the firewall and advanced security enforcement. Possible values are: notConfigured, blocked, allowed. */
-				firewallEnabled: StateManagementSetting
-	    
+		firewallEnabled?: StateManagementSetting
+
 	    /** Prevent the server from operating in stealth mode */
-				stealthModeBlocked: boolean
-	    
+		stealthModeBlocked?: boolean
+
 	    /** Configures the firewall to block all incoming traffic regardless of other policy settings */
-				incomingTrafficBlocked: boolean
-	    
+		incomingTrafficBlocked?: boolean
+
 	    /** Configures the firewall to block unicast responses to multicast broadcast traffic */
-				unicastResponsesToMulticastBroadcastsBlocked: boolean
-	    
+		unicastResponsesToMulticastBroadcastsBlocked?: boolean
+
 	    /** Prevents the firewall from displaying notifications when an application is blocked from listening on a port */
-				inboundNotificationsBlocked: boolean
-	    
+		inboundNotificationsBlocked?: boolean
+
 	    /** Configures the firewall to merge authorized application rules from group policy with those from local store instead of ignoring the local store rules */
-				authorizedApplicationRulesFromGroupPolicyMerged: boolean
-	    
+		authorizedApplicationRulesFromGroupPolicyMerged?: boolean
+
 	    /** Configures the firewall to merge global port rules from group policy with those from local store instead of ignoring the local store rules */
-				globalPortRulesFromGroupPolicyMerged: boolean
-	    
+		globalPortRulesFromGroupPolicyMerged?: boolean
+
 	    /** Configures the firewall to merge connection security rules from group policy with those from local store instead of ignoring the local store rules */
-				connectionSecurityRulesFromGroupPolicyMerged: boolean
-	    
+		connectionSecurityRulesFromGroupPolicyMerged?: boolean
+
 	    /** Configures the firewall to block all outgoing connections by default */
-				outboundConnectionsBlocked: boolean
-	    
+		outboundConnectionsBlocked?: boolean
+
 	    /** Configures the firewall to block all incoming connections by default */
-				inboundConnectionsBlocked: boolean
-	    
+		inboundConnectionsBlocked?: boolean
+
 	    /** Configures the firewall to allow the host computer to respond to unsolicited network traffic of that traffic is secured by IPSec even when stealthModeBlocked is set to true */
-				securedPacketExemptionAllowed: boolean
-	    
+		securedPacketExemptionAllowed?: boolean
+
 	    /** Configures the firewall to merge Firewall Rule policies from group policy with those from local store instead of ignoring the local store rules */
-				policyRulesFromGroupPolicyMerged: boolean
-	    
+		policyRulesFromGroupPolicyMerged?: boolean
+
 }
 export interface BitLockerRemovableDrivePolicy {
 
 	    /** Select the encryption method for removable  drives. Possible values are: aesCbc128, aesCbc256, xtsAes128, xtsAes256. */
-				encryptionMethod?: BitLockerEncryptionMethod
-	    
+		encryptionMethod?: BitLockerEncryptionMethod
+
 	    /** Indicates whether to block write access to devices configured in another organization.  If requireEncryptionForWriteAccess is false, this value does not affect. */
-				requireEncryptionForWriteAccess: boolean
-	    
+		requireEncryptionForWriteAccess?: boolean
+
 	    /** This policy setting determines whether BitLocker protection is required for removable data drives to be writable on a computer. */
-				blockCrossOrganizationWriteAccess: boolean
-	    
+		blockCrossOrganizationWriteAccess?: boolean
+
 }
 export interface DefenderDetectedMalwareActions {
 
 	    /** Indicates a Defender action to take for low severity Malware threat detected. Possible values are: deviceDefault, clean, quarantine, remove, allow, userDefined, block. */
-				lowSeverity: DefenderThreatAction
-	    
+		lowSeverity?: DefenderThreatAction
+
 	    /** Indicates a Defender action to take for moderate severity Malware threat detected. Possible values are: deviceDefault, clean, quarantine, remove, allow, userDefined, block. */
-				moderateSeverity: DefenderThreatAction
-	    
+		moderateSeverity?: DefenderThreatAction
+
 	    /** Indicates a Defender action to take for high severity Malware threat detected. Possible values are: deviceDefault, clean, quarantine, remove, allow, userDefined, block. */
-				highSeverity: DefenderThreatAction
-	    
+		highSeverity?: DefenderThreatAction
+
 	    /** Indicates a Defender action to take for severe severity Malware threat detected. Possible values are: deviceDefault, clean, quarantine, remove, allow, userDefined, block. */
-				severeSeverity: DefenderThreatAction
-	    
+		severeSeverity?: DefenderThreatAction
+
 }
 export interface Windows10NetworkProxyServer {
 
-	    /** Address to the proxy server. Specify an address in the format [“:”] */
-				address: string
-	    
+	    /** Address to the proxy server. Specify an address in the format [":"] */
+		address?: string
+
 	    /** Addresses that should not use the proxy server. The system will not use the proxy server for addresses beginning with what is specified in this node. */
-				exceptions?: string[]
-	    
+		exceptions?: string[]
+
 	    /** Specifies whether the proxy server should be used for local (intranet) addresses. */
-				useForLocalAddresses: boolean
-	    
+		useForLocalAddresses?: boolean
+
 }
 export interface EdgeSearchEngineBase {
 
@@ -10501,29 +10885,29 @@ export interface EdgeSearchEngineBase {
 export interface EdgeSearchEngineCustom extends EdgeSearchEngineBase {
 
 	    /** Points to a https link containing the OpenSearch xml file that contains, at minimum, the short name and the URL to the search Engine. */
-				edgeSearchEngineOpenSearchXmlUrl: string
-	    
+		edgeSearchEngineOpenSearchXmlUrl?: string
+
 }
 export interface EdgeSearchEngine extends EdgeSearchEngineBase {
 
 	    /** Allows IT admins to set a predefined default search engine for MDM-Controlled devices. Possible values are: default, bing. */
-				edgeSearchEngineType: EdgeSearchEngineType
-	    
+		edgeSearchEngineType?: EdgeSearchEngineType
+
 }
 export interface SharedPCAccountManagerPolicy {
 
 	    /** Configures when accounts are deleted. Possible values are: immediate, diskSpaceThreshold, diskSpaceThresholdOrInactiveThreshold. */
-				accountDeletionPolicy: SharedPCAccountDeletionPolicyType
-	    
+		accountDeletionPolicy?: SharedPCAccountDeletionPolicyType
+
 	    /** Sets the percentage of available disk space a PC should have before it stops deleting cached shared PC accounts. Only applies when AccountDeletionPolicy is DiskSpaceThreshold or DiskSpaceThresholdOrInactiveThreshold. Valid values 0 to 100 */
-				cacheAccountsAboveDiskFreePercentage?: number
-	    
+		cacheAccountsAboveDiskFreePercentage?: number
+
 	    /** Specifies when the accounts will start being deleted when they have not been logged on during the specified period, given as number of days. Only applies when AccountDeletionPolicy is DiskSpaceThreshold or DiskSpaceThresholdOrInactiveThreshold. */
-				inactiveThresholdDays?: number
-	    
+		inactiveThresholdDays?: number
+
 	    /** Sets the percentage of disk space remaining on a PC before cached accounts will be deleted to free disk space. Accounts that have been inactive the longest will be deleted first. Only applies when AccountDeletionPolicy is DiskSpaceThresholdOrInactiveThreshold. Valid values 0 to 100 */
-				removeAccountsBelowDiskFreePercentage?: number
-	    
+		removeAccountsBelowDiskFreePercentage?: number
+
 }
 export interface WindowsUpdateInstallScheduleType {
 
@@ -10531,122 +10915,122 @@ export interface WindowsUpdateInstallScheduleType {
 export interface WindowsUpdateScheduledInstall extends WindowsUpdateInstallScheduleType {
 
 	    /** Scheduled Install Day in week. Possible values are: userDefined, everyday, sunday, monday, tuesday, wednesday, thursday, friday, saturday. */
-				scheduledInstallDay: WeeklySchedule
-	    
+		scheduledInstallDay?: WeeklySchedule
+
 	    /** Scheduled Install Time during day */
-				scheduledInstallTime: string
-	    
+		scheduledInstallTime?: string
+
 }
 export interface WindowsUpdateActiveHoursInstall extends WindowsUpdateInstallScheduleType {
 
 	    /** Active Hours Start */
-				activeHoursStart: string
-	    
+		activeHoursStart?: string
+
 	    /** Active Hours End */
-				activeHoursEnd: string
-	    
+		activeHoursEnd?: string
+
 }
 export interface DeviceConfigurationSettingState {
 
 	    /** The setting that is being reported */
-				setting?: string
-	    
+		setting?: string
+
 	    /** Localized/user friendly setting name that is being reported */
-				settingName?: string
-	    
+		settingName?: string
+
 	    /** Name of setting instance that is being reported. */
-				instanceDisplayName?: string
-	    
+		instanceDisplayName?: string
+
 	    /** The compliance state of the setting. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-				state: ComplianceStatus
-	    
+		state?: ComplianceStatus
+
 	    /** Error code for the setting */
-				errorCode: number
-	    
+		errorCode?: number
+
 	    /** Error description */
-				errorDescription?: string
-	    
+		errorDescription?: string
+
 	    /** UserId */
-				userId?: string
-	    
+		userId?: string
+
 	    /** UserName */
-				userName?: string
-	    
+		userName?: string
+
 	    /** UserEmail */
-				userEmail?: string
-	    
+		userEmail?: string
+
 	    /** UserPrincipalName. */
-				userPrincipalName?: string
-	    
+		userPrincipalName?: string
+
 	    /** Contributing policies */
-				sources?: SettingSource[]
-	    
+		sources?: SettingSource[]
+
 	    /** Current value of setting on device */
-				currentValue?: string
-	    
+		currentValue?: string
+
 }
 export interface SettingSource {
 
 	    /** Not yet documented */
-				id?: string
-	    
+		id?: string
+
 	    /** Not yet documented */
-				displayName?: string
-	    
+		displayName?: string
+
 }
 export interface DeviceCompliancePolicySettingState {
 
 	    /** The setting that is being reported */
-				setting?: string
-	    
+		setting?: string
+
 	    /** Localized/user friendly setting name that is being reported */
-				settingName?: string
-	    
+		settingName?: string
+
 	    /** Name of setting instance that is being reported. */
-				instanceDisplayName?: string
-	    
+		instanceDisplayName?: string
+
 	    /** The compliance state of the setting. Possible values are: unknown, notApplicable, compliant, remediated, nonCompliant, error, conflict. */
-				state: ComplianceStatus
-	    
+		state?: ComplianceStatus
+
 	    /** Error code for the setting */
-				errorCode: number
-	    
+		errorCode?: number
+
 	    /** Error description */
-				errorDescription?: string
-	    
+		errorDescription?: string
+
 	    /** UserId */
-				userId?: string
-	    
+		userId?: string
+
 	    /** UserName */
-				userName?: string
-	    
+		userName?: string
+
 	    /** UserEmail */
-				userEmail?: string
-	    
+		userEmail?: string
+
 	    /** UserPrincipalName. */
-				userPrincipalName?: string
-	    
+		userPrincipalName?: string
+
 	    /** Contributing policies */
-				sources?: SettingSource[]
-	    
+		sources?: SettingSource[]
+
 	    /** Current value of setting on device */
-				currentValue?: string
-	    
+		currentValue?: string
+
 }
 export interface DeviceEnrollmentPlatformRestriction {
 
 	    /** Block the platform from enrolling */
-				platformBlocked: boolean
-	    
+		platformBlocked?: boolean
+
 	    /** Block personally owned devices from enrolling */
-				personalDeviceEnrollmentBlocked: boolean
-	    
+		personalDeviceEnrollmentBlocked?: boolean
+
 	    /** Min OS version supported */
-				osMinimumVersion?: string
-	    
+		osMinimumVersion?: string
+
 	    /** Max OS version supported */
-				osMaximumVersion?: string
-	    
+		osMaximumVersion?: string
+
 }
 export interface MobileAppIdentifier {
 
@@ -10654,92 +11038,92 @@ export interface MobileAppIdentifier {
 export interface ManagedAppDiagnosticStatus {
 
 	    /** The validation friendly name */
-				validationName?: string
-	    
+		validationName?: string
+
 	    /** The state of the operation */
-				state?: string
-	    
+		state?: string
+
 	    /** Instruction on how to mitigate a failed validation */
-				mitigationInstruction?: string
-	    
+		mitigationInstruction?: string
+
 }
 export interface KeyValuePair {
 
 	    /** Name for this key-value pair */
-				name: string
-	    
+		name?: string
+
 	    /** Value for this key-value pair */
-				value?: string
-	    
+		value?: string
+
 }
 export interface WindowsInformationProtectionResourceCollection {
 
 	    /** Display name */
-				displayName: string
-	    
+		displayName?: string
+
 	    /** Collection of resources */
-				resources?: string[]
-	    
+		resources?: string[]
+
 }
 export interface WindowsInformationProtectionDataRecoveryCertificate {
 
 	    /** Data recovery Certificate subject name */
-				subjectName?: string
-	    
+		subjectName?: string
+
 	    /** Data recovery Certificate description */
-				description?: string
-	    
+		description?: string
+
 	    /** Data recovery Certificate expiration datetime */
-				expirationDateTime: string
-	    
+		expirationDateTime?: string
+
 	    /** Data recovery Certificate */
-				certificate?: number
-	    
+		certificate?: number
+
 }
 export interface WindowsInformationProtectionApp {
 
 	    /** App display name. */
-				displayName: string
-	    
+		displayName?: string
+
 	    /** The app's description. */
-				description?: string
-	    
+		description?: string
+
 	    /** The publisher name */
-				publisherName?: string
-	    
+		publisherName?: string
+
 	    /** The product name. */
-				productName?: string
-	    
+		productName?: string
+
 	    /** If true, app is denied protection or exemption. */
-				denied: boolean
-	    
+		denied?: boolean
+
 }
 export interface WindowsInformationProtectionProxiedDomainCollection {
 
 	    /** Display name */
-				displayName: string
-	    
+		displayName?: string
+
 	    /** Collection of proxied domains */
-				proxiedDomains: ProxiedDomain[]
-	    
+		proxiedDomains?: ProxiedDomain[]
+
 }
 export interface ProxiedDomain {
 
 	    /** The IP address or FQDN */
-				ipAddressOrFQDN: string
-	    
+		ipAddressOrFQDN?: string
+
 	    /** Proxy IP */
-				proxy?: string
-	    
+		proxy?: string
+
 }
 export interface WindowsInformationProtectionIPRangeCollection {
 
 	    /** Display name */
-				displayName: string
-	    
+		displayName?: string
+
 	    /** Collection of ip ranges */
-				ranges: IpRange[]
-	    
+		ranges?: IpRange[]
+
 }
 export interface IpRange {
 
@@ -10747,23 +11131,23 @@ export interface IpRange {
 export interface AndroidMobileAppIdentifier extends MobileAppIdentifier {
 
 	    /** The identifier for an app, as specified in the play store. */
-				packageId: string
-	    
+		packageId?: string
+
 }
 export interface IosMobileAppIdentifier extends MobileAppIdentifier {
 
 	    /** The identifier for an app, as specified in the app store. */
-				bundleId: string
-	    
+		bundleId?: string
+
 }
 export interface ManagedAppPolicyDeploymentSummaryPerApp {
 
 	    /** Deployment of an app. */
-				mobileAppIdentifier?: MobileAppIdentifier
-	    
+		mobileAppIdentifier?: MobileAppIdentifier
+
 	    /** Number of users the policy is applied. */
-				configurationAppliedUserCount: number
-	    
+		configurationAppliedUserCount?: number
+
 }
 export interface WindowsInformationProtectionStoreApp extends WindowsInformationProtectionApp {
 
@@ -10771,77 +11155,344 @@ export interface WindowsInformationProtectionStoreApp extends WindowsInformation
 export interface WindowsInformationProtectionDesktopApp extends WindowsInformationProtectionApp {
 
 	    /** The binary name. */
-				binaryName: string
-	    
+		binaryName?: string
+
 	    /** The lower binary version. */
-				binaryVersionLow?: string
-	    
+		binaryVersionLow?: string
+
 	    /** The high binary version. */
-				binaryVersionHigh?: string
-	    
+		binaryVersionHigh?: string
+
 }
 export interface IPv6Range extends IpRange {
 
 	    /** Lower IP Address */
-				lowerAddress: string
-	    
+		lowerAddress?: string
+
 	    /** Upper IP Address */
-				upperAddress: string
-	    
+		upperAddress?: string
+
 }
 export interface IPv4Range extends IpRange {
 
 	    /** Lower IP Address */
-				lowerAddress: string
-	    
+		lowerAddress?: string
+
 	    /** Upper IP Address */
-				upperAddress: string
-	    
+		upperAddress?: string
+
 }
 export interface RolePermission {
 
 	    /** Actions */
-				resourceActions?: ResourceAction[]
-	    
+		resourceActions?: ResourceAction[]
+
 }
 export interface ResourceAction {
 
 	    /** Allowed Actions */
-				allowedResourceActions?: string[]
-	    
+		allowedResourceActions?: string[]
+
 	    /** Not Allowed Actions */
-				notAllowedResourceActions?: string[]
-	    
+		notAllowedResourceActions?: string[]
+
 }
 export interface ImageInfo {
 
 	    /** Optional; URI that points to an icon which represents the application used to generate the activity */
-				iconUrl?: string
-	    
-				alternativeText?: string
-	    
+		iconUrl?: string
+
+		alternativeText?: string
+
 	    /** Optional; alt-text accessible content for the image */
-				alternateText?: string
-	    
+		alternateText?: string
+
 	    /** Optional; parameter used to indicate the server is able to render image dynamically in response to parameterization. For example – a high contrast image */
-				addImageQuery?: boolean
-	    
+		addImageQuery?: boolean
+
 }
 export interface VisualInfo {
 
 	    /** Optional. JSON object used to represent an icon which represents the application used to generate the activity */
-				attribution?: ImageInfo
-	    
+		attribution?: ImageInfo
+
 	    /** Optional. Background color used to render the activity in the UI - brand color for the application source of the activity. Must be a valid hex color */
-				backgroundColor?: string
-	    
+		backgroundColor?: string
+
 	    /** Optional. Longer text description of the user's unique activity (example: document name, first sentence, and/or metadata) */
-				description?: string
-	    
+		description?: string
+
 	    /** Required. Short text description of the user's unique activity (for example, document name in cases where an activity refers to document creation) */
-				displayText: string
-	    
+		displayText?: string
+
 	    /** Optional. Custom piece of data - JSON object used to provide custom content to render the activity in the Windows Shell UI */
-				content?: any
-	    
+		content?: any
+
+}
+export interface CloudAppSecurityState {
+
+		destinationServiceIp?: string
+
+		destinationServiceName?: string
+
+		riskScore?: string
+
+}
+export interface FileSecurityState {
+
+		fileHash?: FileHash
+
+		name?: string
+
+		path?: string
+
+		riskScore?: string
+
+}
+export interface FileHash {
+
+		hashType?: FileHashType
+
+		hashValue?: string
+
+}
+export interface HostSecurityState {
+
+		fqdn?: string
+
+		isAzureAdJoined?: boolean
+
+		isAzureAdRegistered?: boolean
+
+		isHybridAzureDomainJoined?: boolean
+
+		netBiosName?: string
+
+		os?: string
+
+		privateIpAddress?: string
+
+		publicIpAddress?: string
+
+		riskScore?: string
+
+}
+export interface MalwareState {
+
+		category?: string
+
+		family?: string
+
+		name?: string
+
+		severity?: string
+
+		wasRunning?: boolean
+
+}
+export interface NetworkConnection {
+
+		applicationName?: string
+
+		destinationAddress?: string
+
+		destinationDomain?: string
+
+		destinationPort?: string
+
+		destinationUrl?: string
+
+		direction?: ConnectionDirection
+
+		domainRegisteredDateTime?: string
+
+		localDnsName?: string
+
+		natDestinationAddress?: string
+
+		natDestinationPort?: string
+
+		natSourceAddress?: string
+
+		natSourcePort?: string
+
+		protocol?: SecurityNetworkProtocol
+
+		riskScore?: string
+
+		sourceAddress?: string
+
+		sourcePort?: string
+
+		status?: ConnectionStatus
+
+		urlParameters?: string
+
+}
+export interface Process {
+
+		accountName?: string
+
+		commandLine?: string
+
+		createdDateTime?: string
+
+		fileHash?: FileHash
+
+		integrityLevel?: ProcessIntegrityLevel
+
+		isElevated?: boolean
+
+		name?: string
+
+		parentProcessCreatedDateTime?: string
+
+		parentProcessId?: number
+
+		parentProcessName?: string
+
+		path?: string
+
+		processId?: number
+
+}
+export interface RegistryKeyState {
+
+		hive?: RegistryHive
+
+		key?: string
+
+		oldKey?: string
+
+		oldValueData?: string
+
+		oldValueName?: string
+
+		operation?: RegistryOperation
+
+		processId?: number
+
+		valueData?: string
+
+		valueName?: string
+
+		valueType?: RegistryValueType
+
+}
+export interface AlertTrigger {
+
+		name?: string
+
+		type?: string
+
+		value?: string
+
+}
+export interface UserSecurityState {
+
+		aadUserId?: string
+
+		accountName?: string
+
+		domainName?: string
+
+		emailRole?: EmailRole
+
+		isVpn?: boolean
+
+		logonDateTime?: string
+
+		logonId?: string
+
+		logonIp?: string
+
+		logonLocation?: string
+
+		logonType?: LogonType
+
+		onPremisesSecurityIdentifier?: string
+
+		riskScore?: string
+
+		userAccountType?: UserAccountSecurityType
+
+		userPrincipalName?: string
+
+}
+export interface SecurityVendorInformation {
+
+		provider?: string
+
+		providerVersion?: string
+
+		subProvider?: string
+
+		vendor?: string
+
+}
+export interface VulnerabilityState {
+
+		cve?: string
+
+		severity?: string
+
+		wasRunning?: boolean
+
+}
+export interface ResourceVisualization {
+
+		title?: string
+
+		type?: string
+
+		mediaType?: string
+
+		previewImageUrl?: string
+
+		previewText?: string
+
+		containerWebUrl?: string
+
+		containerDisplayName?: string
+
+		containerType?: string
+
+}
+export interface ResourceReference {
+
+		webUrl?: string
+
+		id?: string
+
+		type?: string
+
+}
+export interface SharingDetail {
+
+		sharedBy?: InsightIdentity
+
+		sharedDateTime?: string
+
+		sharingSubject?: string
+
+		sharingType?: string
+
+		sharingReference?: ResourceReference
+
+}
+export interface InsightIdentity {
+
+		displayName?: string
+
+		id?: string
+
+		address?: string
+
+}
+export interface UsageDetails {
+
+		lastAccessedDateTime?: string
+
+		lastModifiedDateTime?: string
+
 }


### PR DESCRIPTION
1. Sharepoint issue: In particular the Entity type’s id and the createdDateTime and lastModifiedDateTime fields are now not nullable. This makes list creation in SharePoint problematic since those fields are server generated and shouldn’t be expected when you’re doing a POST to create a list or Column Definition (both of which derive from those base types).

Potentially a blocker for web part demo for Ignite. so reverting the strict model types generation.

2. Updating models with respect to the new [metadata](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/blob/dev/metadata/2018_09_14/v1.0_2018_09_14_descriptions.xml)