### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@microsoft/microsoft-graph-types",
   "description": "Types for Microsoft Graph objects",
   "version": "1.9.0",
+  "license": "MIT",
   "types": "microsoft-graph.d.ts",
   "scripts": {
     "test": "tsc && mocha spec/"


### PR DESCRIPTION
Important for license checkers such as the Microsoft component governance checker.