### PR TITLE
TypeScript error with `ChatMessageMention`

### DIFF
--- a/microsoft-graph.d.ts
+++ b/microsoft-graph.d.ts
@@ -13401,7 +13401,7 @@ export interface ChatMessageAttachment {
      */
     thumbnailUrl?: string;
 }
-export interface ChatMessageMention extends Entity {
+export interface ChatMessageMention {
     id?: number;
     // String used to represent the mention. For example, a user's display name, a team name.
     mentionText?: string;


### PR DESCRIPTION
On TypeScript >= 3.9.5 the following error occurs when using the `master` branch of the MS Graph typings:

```
node_modules/@microsoft/microsoft-graph-types/microsoft-graph.d.ts:13404:18 - error TS2430: Interface 'ChatMessageMention' incorrectly extends interface 'Entity'.
  Types of property 'id' are incompatible.
    Type 'number | undefined' is not assignable to type 'string | undefined'.
      Type 'number' is not assignable to type 'string | undefined'.

13404 export interface ChatMessageMention extends Entity {
```

This is because ChatMessageMention requires an `id` of `number`, but the over-arching `Entity` class defines `id` as a `string`. This patch corrects this issue removing the `Entity` association.

I am working on macOS, so I can make the appropriate changes to `msgraph-metadata` upstream, but I _cannot_ generate the result with Typewriter because `MSGraph-SDK-Code-Generator` does not support .NET Core and Mono falls apart when generating. This patch **SHOULD NOT BE MERGED AS IS** but rather the appropriate changes should be made upstream and regenerated, regardless this is a starting point.