### PR TITLE
TypeScript Namespaces Release

### DIFF
--- a/microsoft-graph.d.ts
+++ b/microsoft-graph.d.ts
@@ -13874,10 +13874,9 @@ export interface TimeRange {
     endTime?: NullableOption<string>;
 }
 
-
 export namespace CallRecords {
-    export type CallType = "unknown" | "groupCall" | "peerToPeer" | "unknownFutureValue";
-    export type ClientPlatform =
+    type CallType = "unknown" | "groupCall" | "peerToPeer" | "unknownFutureValue";
+    type ClientPlatform =
         | "unknown"
         | "windows"
         | "macOS"
@@ -13889,11 +13888,11 @@ export namespace CallRecords {
         | "surfaceHub"
         | "holoLens"
         | "unknownFutureValue";
-    export type FailureStage = "unknown" | "callSetup" | "midcall" | "unknownFutureValue";
-    export type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
-    export type NetworkConnectionType = "unknown" | "wired" | "wifi" | "mobile" | "tunnel" | "unknownFutureValue";
-    export type ProductFamily = "unknown" | "teams" | "skypeForBusiness" | "lync" | "unknownFutureValue";
-    export type ServiceRole =
+    type FailureStage = "unknown" | "callSetup" | "midcall" | "unknownFutureValue";
+    type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
+    type NetworkConnectionType = "unknown" | "wired" | "wifi" | "mobile" | "tunnel" | "unknownFutureValue";
+    type ProductFamily = "unknown" | "teams" | "skypeForBusiness" | "lync" | "unknownFutureValue";
+    type ServiceRole =
         | "unknown"
         | "customBot"
         | "skypeForBusinessMicrosoftTeamsGateway"
@@ -13916,9 +13915,9 @@ export namespace CallRecords {
         | "responseGroupService"
         | "voicemail"
         | "unknownFutureValue";
-    export type UserFeedbackRating = "notRated" | "bad" | "poor" | "fair" | "good" | "excellent" | "unknownFutureValue";
-    export type WifiBand = "unknown" | "frequency24GHz" | "frequency50GHz" | "frequency60GHz" | "unknownFutureValue";
-    export type WifiRadioType =
+    type UserFeedbackRating = "notRated" | "bad" | "poor" | "fair" | "good" | "excellent" | "unknownFutureValue";
+    type WifiBand = "unknown" | "frequency24GHz" | "frequency50GHz" | "frequency60GHz" | "unknownFutureValue";
+    type WifiRadioType =
         | "unknown"
         | "wifi80211a"
         | "wifi80211b"
@@ -13927,8 +13926,8 @@ export namespace CallRecords {
         | "wifi80211ac"
         | "wifi80211ax"
         | "unknownFutureValue";
-    export type Modality = "audio" | "video" | "videoBasedScreenSharing" | "data" | "screenSharing" | "unknownFutureValue";
-    export interface CallRecord extends microsoftgraph.Entity {
+    type Modality = "audio" | "video" | "videoBasedScreenSharing" | "data" | "screenSharing" | "unknownFutureValue";
+    interface CallRecord extends microsoftgraph.Entity {
         /**
          * Monotonically increasing version of the call record. Higher version call records with the same id includes additional
          * data compared to the lower version.
@@ -13969,7 +13968,7 @@ export namespace CallRecords {
          */
         sessions?: NullableOption<Session[]>;
     }
-    export interface Session extends microsoftgraph.Entity {
+    interface Session extends microsoftgraph.Entity {
         /**
          * List of modalities present in the session. Possible values are: unknown, audio, video, videoBasedScreenSharing, data,
          * screenSharing, unknownFutureValue.
@@ -13996,7 +13995,7 @@ export namespace CallRecords {
         // The list of segments involved in the session. Read-only. Nullable.
         segments?: NullableOption<Segment[]>;
     }
-    export interface Segment extends microsoftgraph.Entity {
+    interface Segment extends microsoftgraph.Entity {
         /**
          * UTC time when the segment started. The DateTimeOffset type represents date and time information using ISO 8601 format
          * and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
@@ -14016,23 +14015,23 @@ export namespace CallRecords {
         // Media associated with this segment.
         media?: NullableOption<Media[]>;
     }
-    export interface Endpoint {
+    interface Endpoint {
         // User-agent reported by this endpoint.
         userAgent?: NullableOption<UserAgent>;
     }
-    export interface UserAgent {
+    interface UserAgent {
         // User-agent header value reported by this endpoint.
         headerValue?: NullableOption<string>;
         // Identifies the version of application software used by this endpoint.
         applicationVersion?: NullableOption<string>;
     }
-    export interface FailureInfo {
+    interface FailureInfo {
         // The stage when the failure occurred. Possible values are: unknown, callSetup, midcall, unknownFutureValue.
         stage?: FailureStage;
         // Classification of why a call or portion of a call failed.
         reason?: NullableOption<string>;
     }
-    export interface Media {
+    interface Media {
         // How the media was identified during media negotiation stage.
         label?: NullableOption<string>;
         // Network information associated with the caller endpoint of this media.
@@ -14046,7 +14045,7 @@ export namespace CallRecords {
         // Network streams associated with this media.
         streams?: NullableOption<MediaStream[]>;
     }
-    export interface NetworkInfo {
+    interface NetworkInfo {
         // IP address of the media endpoint.
         ipAddress?: NullableOption<string>;
         // Subnet used for media stream by the media endpoint.
@@ -14117,7 +14116,7 @@ export namespace CallRecords {
          */
         bandwidthLowEventRatio?: NullableOption<number>;
     }
-    export interface DeviceInfo {
+    interface DeviceInfo {
         // Name of the capture device used by the media endpoint.
         captureDeviceName?: NullableOption<string>;
         // Name of the capture device driver used by the media endpoint.
@@ -14188,7 +14187,7 @@ export namespace CallRecords {
         // Glitches per 5 minute internal for the media endpoint's loudspeaker.
         speakerGlitchRate?: NullableOption<number>;
     }
-    export interface MediaStream {
+    interface MediaStream {
         // Unique identifier for the stream.
         streamId?: NullableOption<string>;
         /**
@@ -14279,13 +14278,13 @@ export namespace CallRecords {
          */
         maxAudioNetworkJitter?: NullableOption<string>;
     }
-    export interface ParticipantEndpoint extends Endpoint {
+    interface ParticipantEndpoint extends Endpoint {
         // Identity associated with the endpoint.
         identity?: NullableOption<microsoftgraph.IdentitySet>;
         // The feedback provided by the user of this endpoint about the quality of the session.
         feedback?: NullableOption<UserFeedback>;
     }
-    export interface UserFeedback {
+    interface UserFeedback {
         // The feedback text provided by the user of this endpoint for the session.
         text?: NullableOption<string>;
         /**
@@ -14300,10 +14299,10 @@ export namespace CallRecords {
         tokens?: NullableOption<FeedbackTokenSet>;
     }
 // tslint:disable-next-line: no-empty-interface
-    export interface FeedbackTokenSet {}
+    interface FeedbackTokenSet {}
 // tslint:disable-next-line: no-empty-interface
-    export interface ServiceEndpoint extends Endpoint {}
-    export interface ClientUserAgent extends UserAgent {
+    interface ServiceEndpoint extends Endpoint {}
+    interface ClientUserAgent extends UserAgent {
         /**
          * Identifies the platform used by this endpoint. Possible values are: unknown, windows, macOS, iOS, android, web,
          * ipPhone, roomSystem, surfaceHub, holoLens, unknownFutureValue.
@@ -14315,7 +14314,7 @@ export namespace CallRecords {
          */
         productFamily?: ProductFamily;
     }
-    export interface ServiceUserAgent extends UserAgent {
+    interface ServiceUserAgent extends UserAgent {
         /**
          * Identifies the role of the service used by this endpoint. Possible values are: unknown, customBot,
          * skypeForBusinessMicrosoftTeamsGateway, skypeForBusinessAudioVideoMcu, skypeForBusinessApplicationSharingMcu,
@@ -14328,4 +14327,3 @@ export namespace CallRecords {
         role?: ServiceRole;
     }
 }
-

--- a/microsoft-graph.d.ts
+++ b/microsoft-graph.d.ts
@@ -4900,6 +4900,7 @@ export interface SchemaExtension extends Entity {
 }
 export interface CloudCommunications extends Entity {
     calls?: NullableOption<Call[]>;
+    callRecords?: NullableOption<CallRecords.CallRecord[]>;
     onlineMeetings?: NullableOption<OnlineMeeting[]>;
 }
 export interface Call extends Entity {
@@ -13872,3 +13873,459 @@ export interface TimeRange {
     // End time for the time range.
     endTime?: NullableOption<string>;
 }
+
+
+export namespace CallRecords {
+    export type CallType = "unknown" | "groupCall" | "peerToPeer" | "unknownFutureValue";
+    export type ClientPlatform =
+        | "unknown"
+        | "windows"
+        | "macOS"
+        | "iOS"
+        | "android"
+        | "web"
+        | "ipPhone"
+        | "roomSystem"
+        | "surfaceHub"
+        | "holoLens"
+        | "unknownFutureValue";
+    export type FailureStage = "unknown" | "callSetup" | "midcall" | "unknownFutureValue";
+    export type MediaStreamDirection = "callerToCallee" | "calleeToCaller";
+    export type NetworkConnectionType = "unknown" | "wired" | "wifi" | "mobile" | "tunnel" | "unknownFutureValue";
+    export type ProductFamily = "unknown" | "teams" | "skypeForBusiness" | "lync" | "unknownFutureValue";
+    export type ServiceRole =
+        | "unknown"
+        | "customBot"
+        | "skypeForBusinessMicrosoftTeamsGateway"
+        | "skypeForBusinessAudioVideoMcu"
+        | "skypeForBusinessApplicationSharingMcu"
+        | "skypeForBusinessCallQueues"
+        | "skypeForBusinessAutoAttendant"
+        | "mediationServer"
+        | "mediationServerCloudConnectorEdition"
+        | "exchangeUnifiedMessagingService"
+        | "mediaController"
+        | "conferencingAnnouncementService"
+        | "conferencingAttendant"
+        | "audioTeleconferencerController"
+        | "skypeForBusinessUnifiedCommunicationApplicationPlatform"
+        | "responseGroupServiceAnnouncementService"
+        | "gateway"
+        | "skypeTranslator"
+        | "skypeForBusinessAttendant"
+        | "responseGroupService"
+        | "voicemail"
+        | "unknownFutureValue";
+    export type UserFeedbackRating = "notRated" | "bad" | "poor" | "fair" | "good" | "excellent" | "unknownFutureValue";
+    export type WifiBand = "unknown" | "frequency24GHz" | "frequency50GHz" | "frequency60GHz" | "unknownFutureValue";
+    export type WifiRadioType =
+        | "unknown"
+        | "wifi80211a"
+        | "wifi80211b"
+        | "wifi80211g"
+        | "wifi80211n"
+        | "wifi80211ac"
+        | "wifi80211ax"
+        | "unknownFutureValue";
+    export type Modality = "audio" | "video" | "videoBasedScreenSharing" | "data" | "screenSharing" | "unknownFutureValue";
+    export interface CallRecord extends microsoftgraph.Entity {
+        /**
+         * Monotonically increasing version of the call record. Higher version call records with the same id includes additional
+         * data compared to the lower version.
+         */
+        version?: number;
+        // Indicates the type of the call. Possible values are: unknown, groupCall, peerToPeer, unknownFutureValue.
+        type?: CallType;
+        /**
+         * List of all the modalities used in the call. Possible values are: unknown, audio, video, videoBasedScreenSharing, data,
+         * screenSharing, unknownFutureValue.
+         */
+        modalities?: Modality[];
+        /**
+         * UTC time when the call record was created. The DatetimeOffset type represents date and time information using ISO 8601
+         * format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        lastModifiedDateTime?: string;
+        /**
+         * UTC time when the first user joined the call. The DatetimeOffset type represents date and time information using ISO
+         * 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this:
+         * '2014-01-01T00:00:00Z'
+         */
+        startDateTime?: string;
+        /**
+         * UTC time when the last user left the call. The DateTimeOffset type represents date and time information using ISO 8601
+         * format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        endDateTime?: string;
+        // The organizing party's identity.
+        organizer?: NullableOption<microsoftgraph.IdentitySet>;
+        // List of distinct identities involved in the call.
+        participants?: NullableOption<microsoftgraph.IdentitySet[]>;
+        // Meeting URL associated to the call. May not be available for a peerToPeer call record type.
+        joinWebUrl?: NullableOption<string>;
+        /**
+         * List of sessions involved in the call. Peer-to-peer calls typically only have one session, whereas group calls
+         * typically have at least one session per participant. Read-only. Nullable.
+         */
+        sessions?: NullableOption<Session[]>;
+    }
+    export interface Session extends microsoftgraph.Entity {
+        /**
+         * List of modalities present in the session. Possible values are: unknown, audio, video, videoBasedScreenSharing, data,
+         * screenSharing, unknownFutureValue.
+         */
+        modalities?: Modality[];
+        /**
+         * UTC fime when the first user joined the session. The DateTimeOffset type represents date and time information using ISO
+         * 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this:
+         * '2014-01-01T00:00:00Z'
+         */
+        startDateTime?: string;
+        /**
+         * UTC time when the last user left the session. The DateTimeOffset type represents date and time information using ISO
+         * 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this:
+         * '2014-01-01T00:00:00Z'
+         */
+        endDateTime?: string;
+        // Endpoint that initiated the session.
+        caller?: NullableOption<Endpoint>;
+        // Endpoint that answered the session.
+        callee?: NullableOption<Endpoint>;
+        // Failure information associated with the session if the session failed.
+        failureInfo?: NullableOption<FailureInfo>;
+        // The list of segments involved in the session. Read-only. Nullable.
+        segments?: NullableOption<Segment[]>;
+    }
+    export interface Segment extends microsoftgraph.Entity {
+        /**
+         * UTC time when the segment started. The DateTimeOffset type represents date and time information using ISO 8601 format
+         * and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        startDateTime?: string;
+        /**
+         * UTC time when the segment ended. The DateTimeOffset type represents date and time information using ISO 8601 format and
+         * is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        endDateTime?: string;
+        // Endpoint that initiated this segment.
+        caller?: NullableOption<Endpoint>;
+        // Endpoint that answered this segment.
+        callee?: NullableOption<Endpoint>;
+        // Failure information associated with the segment if it failed.
+        failureInfo?: NullableOption<FailureInfo>;
+        // Media associated with this segment.
+        media?: NullableOption<Media[]>;
+    }
+    export interface Endpoint {
+        // User-agent reported by this endpoint.
+        userAgent?: NullableOption<UserAgent>;
+    }
+    export interface UserAgent {
+        // User-agent header value reported by this endpoint.
+        headerValue?: NullableOption<string>;
+        // Identifies the version of application software used by this endpoint.
+        applicationVersion?: NullableOption<string>;
+    }
+    export interface FailureInfo {
+        // The stage when the failure occurred. Possible values are: unknown, callSetup, midcall, unknownFutureValue.
+        stage?: FailureStage;
+        // Classification of why a call or portion of a call failed.
+        reason?: NullableOption<string>;
+    }
+    export interface Media {
+        // How the media was identified during media negotiation stage.
+        label?: NullableOption<string>;
+        // Network information associated with the caller endpoint of this media.
+        callerNetwork?: NullableOption<NetworkInfo>;
+        // Network information associated with the callee endpoint of this media.
+        calleeNetwork?: NullableOption<NetworkInfo>;
+        // Device information associated with the caller endpoint of this media.
+        callerDevice?: NullableOption<DeviceInfo>;
+        // Device information associated with the callee endpoint of this media.
+        calleeDevice?: NullableOption<DeviceInfo>;
+        // Network streams associated with this media.
+        streams?: NullableOption<MediaStream[]>;
+    }
+    export interface NetworkInfo {
+        // IP address of the media endpoint.
+        ipAddress?: NullableOption<string>;
+        // Subnet used for media stream by the media endpoint.
+        subnet?: NullableOption<string>;
+        // Link speed in bits per second reported by the network adapter used by the media endpoint.
+        linkSpeed?: NullableOption<number>;
+        /**
+         * Type of network used by the media endpoint. Possible values are: unknown, wired, wifi, mobile, tunnel,
+         * unknownFutureValue.
+         */
+        connectionType?: NetworkConnectionType;
+        // Network port number used by media endpoint.
+        port?: NullableOption<number>;
+        /**
+         * IP address of the media endpoint as seen by the media relay server. This is typically the public internet IP address
+         * associated to the endpoint.
+         */
+        reflexiveIPAddress?: NullableOption<string>;
+        // IP address of the media relay server allocated by the media endpoint.
+        relayIPAddress?: NullableOption<string>;
+        // Network port number allocated on the media relay server by the media endpoint.
+        relayPort?: NullableOption<number>;
+        // The media access control (MAC) address of the media endpoint's network device.
+        macAddress?: NullableOption<string>;
+        /**
+         * Name of the Microsoft WiFi driver used by the media endpoint. Value may be localized based on the language used by
+         * endpoint.
+         */
+        wifiMicrosoftDriver?: NullableOption<string>;
+        // Version of the Microsoft WiFi driver used by the media endpoint.
+        wifiMicrosoftDriverVersion?: NullableOption<string>;
+        // Name of the WiFi driver used by the media endpoint. Value may be localized based on the language used by endpoint.
+        wifiVendorDriver?: NullableOption<string>;
+        // Version of the WiFi driver used by the media endpoint.
+        wifiVendorDriverVersion?: NullableOption<string>;
+        // WiFi channel used by the media endpoint.
+        wifiChannel?: NullableOption<number>;
+        /**
+         * WiFi band used by the media endpoint. Possible values are: unknown, frequency24GHz, frequency50GHz, frequency60GHz,
+         * unknownFutureValue.
+         */
+        wifiBand?: WifiBand;
+        // The wireless LAN basic service set identifier of the media endpoint used to connect to the network.
+        basicServiceSetIdentifier?: NullableOption<string>;
+        /**
+         * Type of WiFi radio used by the media endpoint. Possible values are: unknown, wifi80211a, wifi80211b, wifi80211g,
+         * wifi80211n, wifi80211ac, wifi80211ax, unknownFutureValue.
+         */
+        wifiRadioType?: WifiRadioType;
+        // WiFi signal strength in percentage reported by the media endpoint.
+        wifiSignalStrength?: NullableOption<number>;
+        // Estimated remaining battery charge in percentage reported by the media endpoint.
+        wifiBatteryCharge?: NullableOption<number>;
+        // DNS suffix associated with the network adapter of the media endpoint.
+        dnsSuffix?: NullableOption<string>;
+        // Fraction of the call that the media endpoint detected the network was causing poor quality of the audio sent.
+        sentQualityEventRatio?: NullableOption<number>;
+        // Fraction of the call that the media endpoint detected the network was causing poor quality of the audio received.
+        receivedQualityEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected the network delay was significant enough to impact the ability to
+         * have real-time two-way communication.
+         */
+        delayEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected the available bandwidth or bandwidth policy was low enough to
+         * cause poor quality of the audio sent.
+         */
+        bandwidthLowEventRatio?: NullableOption<number>;
+    }
+    export interface DeviceInfo {
+        // Name of the capture device used by the media endpoint.
+        captureDeviceName?: NullableOption<string>;
+        // Name of the capture device driver used by the media endpoint.
+        captureDeviceDriver?: NullableOption<string>;
+        // Name of the render device used by the media endpoint.
+        renderDeviceName?: NullableOption<string>;
+        // Name of the render device driver used by the media endpoint.
+        renderDeviceDriver?: NullableOption<string>;
+        /**
+         * Average energy level of sent audio for audio classified as mono speech, or left channel of stereo speech by the media
+         * endpoint.
+         */
+        sentSignalLevel?: NullableOption<number>;
+        /**
+         * Average energy level of received audio for audio classified as mono speech, or left channel of stereo speech by the
+         * media endpoint.
+         */
+        receivedSignalLevel?: NullableOption<number>;
+        /**
+         * Average energy level of sent audio for audio classified as mono noise or left channel of stereo noise by the media
+         * endpoint.
+         */
+        sentNoiseLevel?: NullableOption<number>;
+        /**
+         * Average energy level of received audio for audio classified as mono noise or left channel of stereo noise by the media
+         * endpoint.
+         */
+        receivedNoiseLevel?: NullableOption<number>;
+        // The root mean square (RMS) of the incoming signal of up to the first 30 seconds of the call.
+        initialSignalLevelRootMeanSquare?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected the CPU resources available were insufficient and caused poor
+         * quality of the audio sent and received.
+         */
+        cpuInsufficentEventRatio?: NullableOption<number>;
+        // Fraction of the call that the media endpoint detected the render device was not working properly.
+        renderNotFunctioningEventRatio?: NullableOption<number>;
+        // Fraction of the call that the media endpoint detected the capture device was not working properly.
+        captureNotFunctioningEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected glitches or gaps in the audio played or captured that caused poor
+         * quality of the audio being sent or received.
+         */
+        deviceGlitchEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected low speech to noise level that caused poor quality of the audio
+         * being sent.
+         */
+        lowSpeechToNoiseEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected low speech level that caused poor quality of the audio being
+         * sent.
+         */
+        lowSpeechLevelEventRatio?: NullableOption<number>;
+        /**
+         * Fraction of the call that the media endpoint detected clipping in the captured audio that caused poor quality of the
+         * audio being sent.
+         */
+        deviceClippingEventRatio?: NullableOption<number>;
+        // Number of times during the call that the media endpoint detected howling or screeching audio.
+        howlingEventCount?: NullableOption<number>;
+        // Fraction of the call that media endpoint detected device render volume is set to 0.
+        renderZeroVolumeEventRatio?: NullableOption<number>;
+        // Fraction of the call that media endpoint detected device render is muted.
+        renderMuteEventRatio?: NullableOption<number>;
+        // Glitches per 5 minute interval for the media endpoint's microphone.
+        micGlitchRate?: NullableOption<number>;
+        // Glitches per 5 minute internal for the media endpoint's loudspeaker.
+        speakerGlitchRate?: NullableOption<number>;
+    }
+    export interface MediaStream {
+        // Unique identifier for the stream.
+        streamId?: NullableOption<string>;
+        /**
+         * UTC time when the stream started. The DateTimeOffset type represents date and time information using ISO 8601 format
+         * and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        startDateTime?: NullableOption<string>;
+        /**
+         * UTC time when the stream ended. The DateTimeOffset type represents date and time information using ISO 8601 format and
+         * is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
+         */
+        endDateTime?: NullableOption<string>;
+        // Indicates the direction of the media stream. Possible values are: callerToCallee, calleeToCaller.
+        streamDirection?: MediaStreamDirection;
+        /**
+         * Average Network Mean Opinion Score degradation for stream. Represents how much the network loss and jitter has impacted
+         * the quality of received audio.
+         */
+        averageAudioDegradation?: NullableOption<number>;
+        /**
+         * Average jitter for the stream computed as specified in [RFC 3550][], denoted in [ISO 8601][] format. For example, 1
+         * second is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator, and 'S' is the second
+         * designator.
+         */
+        averageJitter?: NullableOption<string>;
+        /**
+         * Maximum jitter for the stream computed as specified in RFC 3550, denoted in [ISO 8601][] format. For example, 1 second
+         * is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator, and 'S' is the second
+         * designator.
+         */
+        maxJitter?: NullableOption<string>;
+        // Average packet loss rate for stream.
+        averagePacketLossRate?: NullableOption<number>;
+        // Maximum packet loss rate for the stream.
+        maxPacketLossRate?: NullableOption<number>;
+        /**
+         * Ratio of the number of audio frames with samples generated by packet loss concealment to the total number of audio
+         * frames.
+         */
+        averageRatioOfConcealedSamples?: NullableOption<number>;
+        // Maximum ratio of packets concealed by the healer.
+        maxRatioOfConcealedSamples?: NullableOption<number>;
+        /**
+         * Average network propagation round-trip time computed as specified in [RFC 3550][], denoted in [ISO 8601][] format. For
+         * example, 1 second is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator, and 'S' is
+         * the second designator.
+         */
+        averageRoundTripTime?: NullableOption<string>;
+        /**
+         * Maximum network propagation round-trip time computed as specified in [RFC 3550][], denoted in [ISO 8601][] format. For
+         * example, 1 second is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator, and 'S' is
+         * the second designator.
+         */
+        maxRoundTripTime?: NullableOption<string>;
+        // Packet count for the stream.
+        packetUtilization?: NullableOption<number>;
+        // Average estimated bandwidth available between two endpoints in bits per second.
+        averageBandwidthEstimate?: NullableOption<number>;
+        /**
+         * True if the media stream bypassed the Mediation Server and went straight between client and PSTN Gateway/PBX, false
+         * otherwise.
+         */
+        wasMediaBypassed?: NullableOption<boolean>;
+        // Packet loss rate after FEC has been applied aggregated across all video streams and codecs.
+        postForwardErrorCorrectionPacketLossRate?: NullableOption<number>;
+        // Average percentage of video frames lost as displayed to the user.
+        averageVideoFrameLossPercentage?: NullableOption<number>;
+        // Average frames per second received for all video streams computed over the duration of the session.
+        averageReceivedFrameRate?: NullableOption<number>;
+        // Fraction of the call where frame rate is less than 7.5 frames per second.
+        lowFrameRateRatio?: NullableOption<number>;
+        // Average fraction of packets lost, as specified in [RFC 3550][], computed over the duration of the session.
+        averageVideoPacketLossRate?: NullableOption<number>;
+        // Average frames per second received for a video stream, computed over the duration of the session.
+        averageVideoFrameRate?: NullableOption<number>;
+        // Fraction of the call that the client is running less than 70% expected video processing capability.
+        lowVideoProcessingCapabilityRatio?: NullableOption<number>;
+        /**
+         * Average jitter for the stream computed as specified in [RFC 3550][], denoted in [ISO 8601][] format. For example, 1
+         * second is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator, and 'S' is the second
+         * designator.
+         */
+        averageAudioNetworkJitter?: NullableOption<string>;
+        /**
+         * Maximum of audio network jitter computed over each of the 20 second windows during the session, denoted in [ISO 8601][]
+         * format. For example, 1 second is denoted as 'PT1S', where 'P' is the duration designator, 'T' is the time designator,
+         * and 'S' is the second designator.
+         */
+        maxAudioNetworkJitter?: NullableOption<string>;
+    }
+    export interface ParticipantEndpoint extends Endpoint {
+        // Identity associated with the endpoint.
+        identity?: NullableOption<microsoftgraph.IdentitySet>;
+        // The feedback provided by the user of this endpoint about the quality of the session.
+        feedback?: NullableOption<UserFeedback>;
+    }
+    export interface UserFeedback {
+        // The feedback text provided by the user of this endpoint for the session.
+        text?: NullableOption<string>;
+        /**
+         * The rating provided by the user of this endpoint about the quality of this Session. Possible values are: notRated, bad,
+         * poor, fair, good, excellent, unknownFutureValue.
+         */
+        rating?: UserFeedbackRating;
+        /**
+         * The set of feedback tokens provided by the user of this endpoint for the session. This is a set of Boolean properties.
+         * The property names should not be relied upon since they may change depending on what tokens are offered to the user.
+         */
+        tokens?: NullableOption<FeedbackTokenSet>;
+    }
+// tslint:disable-next-line: no-empty-interface
+    export interface FeedbackTokenSet {}
+// tslint:disable-next-line: no-empty-interface
+    export interface ServiceEndpoint extends Endpoint {}
+    export interface ClientUserAgent extends UserAgent {
+        /**
+         * Identifies the platform used by this endpoint. Possible values are: unknown, windows, macOS, iOS, android, web,
+         * ipPhone, roomSystem, surfaceHub, holoLens, unknownFutureValue.
+         */
+        platform?: ClientPlatform;
+        /**
+         * Identifies the family of application software used by this endpoint. Possible values are: unknown, teams,
+         * skypeForBusiness, lync, unknownFutureValue.
+         */
+        productFamily?: ProductFamily;
+    }
+    export interface ServiceUserAgent extends UserAgent {
+        /**
+         * Identifies the role of the service used by this endpoint. Possible values are: unknown, customBot,
+         * skypeForBusinessMicrosoftTeamsGateway, skypeForBusinessAudioVideoMcu, skypeForBusinessApplicationSharingMcu,
+         * skypeForBusinessCallQueues, skypeForBusinessAutoAttendant, mediationServer, mediationServerCloudConnectorEdition,
+         * exchangeUnifiedMessagingService, mediaController, conferencingAnnouncementService, conferencingAttendant,
+         * audioTeleconferencerController, skypeForBusinessUnifiedCommunicationApplicationPlatform,
+         * responseGroupServiceAnnouncementService, gateway, skypeTranslator, skypeForBusinessAttendant, responseGroupService,
+         * voicemail, unknownFutureValue.
+         */
+        role?: ServiceRole;
+    }
+}
+


### PR DESCRIPTION
### Changes

- `CallRecords` namespace is exported as nested namespace.
- `callRecords` property is added to `CloudCommunications`

### Work Items
[AB#5029](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/5029)