### PR TITLE
Fix PR title for beta typings

### DIFF
--- a/.github/workflows/create-beta-pull-request.yml
+++ b/.github/workflows/create-beta-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MESSAGE_TITLE: Generated models and request builders using Typewriter
+        MESSAGE_TITLE: Generated beta typings using Typewriter
         MESSAGE_BODY: "This pull request was automatically created by the GitHub Action, **${{github.workflow}}**. \n\n The commit hash is _${{github.sha}}_. \n\n **Important** Check for unexpected deletions or changes in this PR. \n\n cc: @darrelmiller"
         REVIEWERS: peombwa,ddyett,MIchaelMainer,baywet,zengin
         ASSIGNEDTO: nikithauc


### PR DESCRIPTION
There is no request builders for TypeScript.
Changed the title to match with v1 PRs.