### PR TITLE
Type base64 encoded FileAttachment.contentBytes as a string

### DIFF
--- a/microsoft-graph.d.ts
+++ b/microsoft-graph.d.ts
@@ -8611,7 +8611,7 @@ export interface EventMessageResponse extends EventMessage {
 }
 export interface FileAttachment extends Attachment {
     // The base64-encoded contents of the file.
-    contentBytes?: NullableOption<number>;
+    contentBytes?: NullableOption<string>;
     // The ID of the attachment in the Exchange store.
     contentId?: NullableOption<string>;
     // Do not use this property as it is not supported.


### PR DESCRIPTION
Thanks for taking the time to review this PR! 

This PR changes the described type of `contentBytes` from ` NullableOption<number>` to ` NullableOption<string>`. 

### Why was it mistyped?
The documentation, imprecisely describes it in contradicting terms: `Edm.Binary` and "The base64-encoded contents of the file." The field cannot be both at the same time. Instead, it is clear from use of the Api that the contents sent and accepted by the Api are base64 encoded (string) of a binary. After decoding, the type would be an `Edm.Binary`, but not in the FileAttachment object itself.

### Impact
Because the type incorrectly describes the contents as a number, test fixtures built using actual FileAttachment responses appear as the wrong shape to Typescript, forcing the test author to cast through `unknown` and effectively reducing the value of the type. 

It was described in this issue: https://github.com/microsoftgraph/msgraph-typescript-typings/issues/23 and never resolved. I suspect this happened because the contradiction of the docs wasn't clearly discussed. We all know base64 encoded binaries are strings, the docs simply mis-describe this in the type field while accurately describing it in the description field. 

Reference: https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-1.0